### PR TITLE
Add eca-chat-talk command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For more details about ECA, check [ECA server](https://github.com/editor-code-as
 - External `eca` server binary
   - Automatic downloaded if `eca-custom-command` is `nil`
   - Place it on your `$PATH` or customize `eca-custom-command`
+- [whisper.el](https://github.com/natrys/whisper.el/blob/master/whisper.el) for Speech-to-Text support (optional)
 
 ## Installation
 
@@ -42,6 +43,25 @@ M-x package-install eca
 2. The dedicated chat window `<eca-chat>` pops up.
 3. Type your prompt after the `> ` and press RET.
 4. Attach more context auto completing after the `@`.
+
+## Usage
+
+### Speech-to-Text support
+
+If you have [whisper.el](https://github.com/natrys/whisper.el/blob/master/whisper.el) installed you can use the `eca-chat-talk`
+command (or use the `C-t` keybinding) to talk to the Editor Code
+Assistant. This will record audio until you press `RET`. Then, the
+recorded audio will be transcribed to text and placed into the chat
+buffer.
+
+We recommend to use the `small`, it is a good trade-off between
+accuracy and transcription speed.
+
+```elisp
+(use-package whisper
+  :custom
+  (whisper-model "small"))
+```
 
 ## Contributing
 

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -129,6 +129,7 @@ Must be a valid model supported by server, check `eca-chat-select-model`."
     (define-key map (kbd "S-<return>") #'eca-chat--key-pressed-newline)
     (define-key map (kbd "S-<return>") #'eca-chat--key-pressed-newline)
     (define-key map (kbd "C-k") #'eca-chat-clear)
+    (define-key map (kbd "C-t") #'eca-chat-talk)
     (define-key map (kbd "<return>") #'eca-chat--key-pressed-return)
     map)
   "Keymap used by `eca-chat-mode'.")
@@ -582,6 +583,36 @@ This is similar to `backward-delete-char' but protects the prompt/context line."
   (interactive)
   (when-let* ((behavior (completing-read "Select a behavior:" (append (eca--session-chat-behaviors eca--session) nil) nil t)))
     (setq eca-chat-custom-behavior behavior)))
+
+(declare-function whisper-run "ext:whisper" ())
+
+(defun eca-chat-talk ()
+  "Talk to the assistent by recording audio and transcribing it."
+  (interactive)
+  (unless (featurep 'whisper)
+    (user-error "Whisper.el is not available, please install it first"))
+  (eca-chat-open)
+  (with-current-buffer (eca-chat--get-buffer)
+    (goto-char (point-max)))
+  (let ((buffer (get-buffer-create "*whisper-stdout*")))
+    (with-current-buffer buffer
+      (erase-buffer)
+      (make-local-variable 'whisper-after-transcription-hook)
+      (add-hook 'whisper-after-transcription-hook
+                (lambda ()
+                  (let ((transcription (buffer-substring
+                                        (line-beginning-position)
+                                        (line-end-position))))
+                    (with-current-buffer eca-chat-buffer-name
+                      (insert transcription)
+                      (newline)
+                      (eca-chat--key-pressed-return))))
+                nil t)
+      (whisper-run)
+      (message "Recording audio. Press RET when you are done.")
+      (while (not (equal ?\r (read-char)))
+        (sit-for 0.5))
+      (whisper-run))))
 
 (provide 'eca-chat)
 ;;; eca-chat.el ends here


### PR DESCRIPTION
This command uses whisper.el (if installed) to record audio until the user presses `RET`. The recorded audio will then be transcribed to text and placed into the chat buffer.

Open questions, things todo:

- Is `eca-chat-talk` a good command name? Other options could be `eca-chat-record`, `eca-chat-whisper`, ....
- The UX uses calls to `message`. Using the eca spinner would be better, but whipser.el itself uses `message` calls under the hood and I wasn't able to silence them (due to them being called in an async way in hooks).
- Maybe we can collaborate with the whipser.el author to silence those message calls and move some of this code into whipser.el (could be useful for other modes).
- A friend recommended me https://github.com/alphacep/vosk-api as an alternative to whipser, but I could not find an Emacs mode for it. 
