### PR TITLE
Show diff blocks in markdown-mode with colors.

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1010,6 +1010,9 @@ If FORCE? decide to OPEN? or not."
   (setq-local eca-chat--history '())
   (setq-local eca-chat--history-index -1)
 
+  ;; Show diff blocks in markdown-mode with colors.
+  (setq-local markdown-fontify-code-blocks-natively t)
+
   (make-local-variable 'completion-at-point-functions)
   (setq-local completion-at-point-functions (list #'eca-chat-completion-at-point))
 


### PR DESCRIPTION
Turns out showing diffs with colors is supported by markdown mode.

<img width="1941" height="1850" alt="image" src="https://github.com/user-attachments/assets/b72c21a8-201d-470b-9a7e-8bacfb507143" />

I haven't checked how this affects other things in the chat buffer, but I hope its an improvement for other code blocks as well ... 