### PR TITLE
Add context transient menu and drop file from context

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1495,6 +1495,21 @@ if ARG is current prefix, ask for file, otherwise add current file."
       (eca-chat-open (eca-session)))))
 
 ;;;###autoload
+(defun eca-chat-drop-file-context (&optional arg)
+  "Drop file from chat as context.
+if ARG is current prefix, ask for file, otherwise add current file."
+  (interactive "P")
+  (eca-assert-session-running (eca-session))
+  (-let ((path (if (equal arg '(4))
+                   (read-file-name "Select the file to drop from context: " (eca-find-root-for-buffer))
+                 (buffer-file-name))))
+    (eca-chat--with-current-buffer (eca-chat--get-buffer (eca-session))
+      (eca-chat--remove-context (list :type "file"
+                                      :path path))
+      (setq eca-chat--track-context nil)
+      (eca-chat-open (eca-session)))))
+
+;;;###autoload
 (defun eca-chat-send-prompt (prompt)
   "Send PROMPT to current chat session."
   (interactive "sPrompt: ")

--- a/eca-util.el
+++ b/eca-util.el
@@ -188,8 +188,13 @@
     ("M" "MCP details" eca-mcp-details)
     ("E" "Show stderr (logs)" eca-show-stderr)]
 
+   ["Context"
+    ("f" "Add current file" eca-chat-add-file-context)
+    ("o" "Drop current file" eca-chat-drop-file-context)
+    ("s" "Add current selection" eca-chat-add-context-at-point)]
+
    ["Server"
-    ("R" "Stop" eca-restart)
+    ("R" "Restart" eca-restart)
     ("S" "Stop" eca-stop)]])
 
 (provide 'eca-util)

--- a/eca-util.el
+++ b/eca-util.el
@@ -190,7 +190,7 @@
 
    ["Context"
     ("f" "Add current file" eca-chat-add-file-context)
-    ("o" "Drop current file" eca-chat-drop-file-context)
+    ("d" "Drop current file" eca-chat-drop-file-context)
     ("s" "Add current selection" eca-chat-add-context-at-point)]
 
    ["Server"


### PR DESCRIPTION
This pull request adds a new feature to allow users to drop a file from the chat context and updates the context menu to include this functionality. The main changes are the introduction of the `eca-chat-drop-file-context` command and its integration into the context menu.

**New chat context management feature:**

* Added the `eca-chat-drop-file-context` command to allow users to remove a file from the chat context, either by dropping the current file or selecting a file if a prefix argument is provided.

**UI/menu improvements:**

* Updated the context menu to include options for adding the current file, dropping the current file, and adding the current selection to the chat context.