### PR TITLE
fix: prevent toggle chat when adding files

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1363,7 +1363,9 @@ string."
             (eca-chat--track-context-at-point))))
       (unless (eca--session-chat session)
         (setf (eca--session-chat session) (current-buffer)))
-      (eca-chat-toggle-window))))
+      (if (window-live-p (get-buffer-window (buffer-name)))
+          (eca-chat--select-window)
+        (eca-chat--pop-window)))))
 
 (defun eca-chat-exit (session)
   "Exit the ECA chat for SESSION."


### PR DESCRIPTION
This pull request updates the logic for displaying the chat window in `eca-chat.el`. Instead of simply toggling the window, it now checks if the chat buffer is already visible and either selects the existing window or pops up a new one as appropriate.
