### PR TITLE
fix: nil description in mcp cause completion to fail

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1289,11 +1289,13 @@ If STATIC? return strs with no dynamic values."
     (eca-chat--relativize-filename-for-workspace-root path roots 'hide-filename)))
 
 (defun eca-chat--completion-prompts-annotate (item-label)
-  "Annonate prompt ITEM-LABEL."
-  (-let (((&plist :description description :arguments args) (get-text-property 0 'eca-chat-completion-item item-label)))
+  "Annotate prompt ITEM-LABEL."
+  (-let (((&plist :description description :arguments args) 
+          (get-text-property 0 'eca-chat-completion-item item-label)))
     (concat "(" (string-join (--map (plist-get it :name) args) ", ")
             ") "
-            (truncate-string-to-width description (* 100 eca-chat-window-width)))))
+            (when description
+              (truncate-string-to-width description (* 100 eca-chat-window-width))))))
 
 (defun eca-chat--completion-context-from-new-context-exit-function (item _status)
   "Add to context the selected ITEM."


### PR DESCRIPTION
Overview
---  

First, thank you for a great project! I have been playing around with ECA, and it's a great package. However, with Corfu enabled, autocompletions did not work with the `/` command if I had an MCP configuration with a `nil` description.  

For example, with the flux-mcp server  

```elisp
eca-chat--completion-prompts-annotate(#("flux-operator-mcp:debug_flux_helmrelease" 0 40 
(eca-chat-completion-item (:name "flux-operator-mcp:debug_flux_helmrelease" :description nil :arguments 
[(:name "name" :description "The name of the Flux resource." :required t)
 (:name "namespace" :description "The namespace of the Flux resource." :required t) 
(:name "cluster" :description "The context name of the cluster, defaults to current." :required nil)] :type "mcpPrompt"))))
```  

Note that the description is nil, and this causes a corfu error.  With the update of the `eca-chat--completion-prompts-annotate` function, this allows for us to check if this is nil and if it is handle it gracefully.  Happy if you want to adjust this in any way, just a simple fix I found for a small bug

<img width="1037" height="485" alt="image" src="https://github.com/user-attachments/assets/58bbea2a-42af-4738-8017-574c51b4b548" />.  


