### PR TITLE
Add custom variable 'eca-find-root-for-buffer-function

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -2271,7 +2271,7 @@ if ARG is current prefix, ask for file, otherwise drop current file."
   (interactive "P")
   (eca-assert-session-running (eca-session))
   (-let ((path (if (equal arg '(4))
-                   (read-file-name "Select the file to drop from context: " (eca-find-root-for-buffer))
+                   (read-file-name "Select the file to drop from context: " (funcall eca-find-root-for-buffer-function))
                  (buffer-file-name))))
     (eca-chat--with-current-buffer (eca-chat--get-last-buffer (eca-session))
       (eca-chat--remove-context (list :type "file"

--- a/eca-util.el
+++ b/eca-util.el
@@ -20,6 +20,11 @@
   :type 'boolean
   :group 'eca)
 
+(defcustom eca-find-root-for-buffer-function #'eca-find-root-for-buffer
+  "Function for getting the ECA's session root."
+  :type 'function
+  :group 'eca)
+
 (defun eca-assoc (map key val)
   "Return a new MAP with KEY associated to flat plist VAL, replacing any existing."
   (cons (cons key val)
@@ -107,7 +112,7 @@
 (defun eca-session ()
   "Return the session related to root of current buffer otherwise nil."
   (or (eca-get eca--sessions eca--session-id-cache)
-      (let* ((root (eca-find-root-for-buffer))
+      (let* ((root (funcall eca-find-root-for-buffer-function))
              (session (-first (lambda (session)
                                 (--first (string= it root)
                                          (eca--session-workspace-folders session)))

--- a/eca.el
+++ b/eca.el
@@ -147,7 +147,7 @@
 
 (defun eca--discover-workspaces ()
   "Ask user for workspaces."
-  (let ((root (eca-find-root-for-buffer))
+  (let ((root (funcall eca-find-root-for-buffer-function))
         (add-workspace? "yes")
         (workspaces '()))
     (while (string= "yes" add-workspace?)
@@ -185,7 +185,7 @@ When ARG is current prefix, ask for workspace roots to use."
   (interactive "P")
   (let* ((workspaces (if (equal arg '(4))
                          (eca--discover-workspaces)
-                       (list (eca-find-root-for-buffer))))
+                       (list (funcall eca-find-root-for-buffer-function))))
          (session (or (eca-session)
                       (eca-create-session workspaces))))
     (pcase (eca--session-status session)


### PR DESCRIPTION
There are cases in which the current project root is not the actual working root, for instance, a monorepo.
This change allows customizing the `eca-find-root-for-buffer-function `with eca-find-root-for-buffer` as the default.
