### PR TITLE
Use gfm-mode instead of gfm-view-mode

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1541,11 +1541,10 @@ string."
 
 ;; Public
 
-(define-derived-mode eca-chat-mode gfm-view-mode  "eca-chat"
+(define-derived-mode eca-chat-mode gfm-mode "eca-chat"
   "Major mode for ECA chat sessions.
 \\{eca-chat-mode-map}"
   :group 'eca
-  ;; force use markdown-mode-map instead of gfm-view-mode-map 
   (visual-line-mode)
   (hl-line-mode -1)
   (read-only-mode -1)


### PR DESCRIPTION
I'm not sure if there is something I'm missing in using `gfm-view-mode`.
but since it makes editing commands (kill-line, delete-char etc.) work in a non expected way
I think we should use `gfm-mode` instead.