### PR TITLE
Support MS-windows line edings in view_ediff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Run tests
       run: |
         eask install-deps
+
+        eask test buttercup
+
         eask package
         eask install
         eask compile

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist
 .eask
 *.elc
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix issue with `view_ediff` displaying empty buffers in ediff. #86

--- a/eca-diff.el
+++ b/eca-diff.el
@@ -51,7 +51,9 @@ ROOTS may be passed for path relativization if desired.
 
 This function tries to be Doom-compatible when Emacs runs Doom popup
 system (it ignores those popup rules for the generated ediff buffers)."
-  (let* ((parsed        (eca-diff-parse-unified-diff diff))
+  (let* (;; ediff expects `\n` line endings.
+         (diff (replace-regexp-in-string "\r\n" "\n" diff))
+         (parsed        (eca-diff-parse-unified-diff diff))
          (orig          (plist-get parsed :original))
          (new           (plist-get parsed :new))
          (buf-orig      (generate-new-buffer (format "*eca-diff-orig:%s*" path)))

--- a/test/eca-diff-test.el
+++ b/test/eca-diff-test.el
@@ -1,0 +1,39 @@
+;;; -*- lexical-binding: t; -*-
+(require 'buttercup)
+(require 'eca-diff)
+
+(defconst native-eol
+  (if (eq system-type 'windows-nt)
+      "\r\n"
+    "\n")
+  "Native end-of-line string for the current operating system.")
+
+(describe "eca-diff-show-ediff"
+          :var ((insert-orig (symbol-function 'insert))
+                (contents '()))
+          (before-each
+           (spy-on 'insert
+                   :and-call-fake (lambda (&rest args)
+                                    (apply insert-orig args)
+                                    (push (list (buffer-name) (buffer-string)) contents )
+                                    )))
+          (it "can display unified diffs with native EOLs"
+              (let* ((inhibit-message t)
+                     (path "/a/path")
+                     (diff (string-join '("@@ -1,3 +1,4 @@"
+                                          "-Line 1"
+                                          "-Line 2"
+                                          "+Line 1 modified"
+                                          "+Line 2"
+                                          "+Line 3 added")
+                                        native-eol)))
+
+                ;; We expect this function to call `insert` twice.
+                (eca-diff-show-ediff path diff)
+                (expect (reverse contents)
+                        :to-equal
+                        `((,(format "*eca-diff-orig:%s*" path) "Line 1
+Line 2")
+                          (,(format "*eca-diff-new:%s*" path) "Line 1 modified
+Line 2
+Line 3 added"))))))


### PR DESCRIPTION
Hi,

can you please consider patch to fix the issue with empty buffers in `view_ediff` on Windows? It addresses #86.

The problem arises because both `eca-diff` and buffer `insert` expect line endings to be `\n`, but diffs on Windows come back from the server with `\r\n` endings.

I’ve taken the liberty of adding a test for the fix using `Buttercup` and created the first CHANGELOG entry, but I can remove them if there are other plans or preferences.

Thanks