### PR TITLE
fix: make `eca-custom-command` serve as described in the docs

### DIFF
--- a/eca-process.el
+++ b/eca-process.el
@@ -206,8 +206,9 @@ https://github.com/emacs-lsp/lsp-mode/issues/4746#issuecomment-2957183423"
   "Return the command to start server."
   (let ((system-command (executable-find "eca")))
     (cond
-     (eca-custom-command (list :decision 'custom
-                               :command eca-custom-command))
+     (eca-custom-command
+      (list :decision 'custom
+            :command (list eca-custom-command "server")))
 
      (system-command
       (list :decision 'system


### PR DESCRIPTION
The `eca-custom-command` only worked if it was set like below:
```emacs-lisp
(setq eca-custom-command (list "/path/to/binary" "server"))
```

This makes `eca-custom-command` serve as described in the docs.
```emacs-lisp
(setq eca-custom-command "/path/to/binary")
```