### PR TITLE
Fix Auto `eca-completion` dow'n work  on `eca-completion-mode`

### DIFF
--- a/eca-completion.el
+++ b/eca-completion.el
@@ -189,7 +189,8 @@ Call ON-ERROR when error."
   "Complete in BUFFER."
   (when (and (buffer-live-p buffer)
              (equal (current-buffer) buffer)
-             (derived-mode-p 'eca-completion-mode))
+             (and (boundp 'eca-completion-mode)
+                  eca-completion-mode))
     (eca-complete)))
 
 (defun eca-completion--self-insert (command)


### PR DESCRIPTION
Because the `derived-mode-p` check is only valid for `majon-mode`, but `eca-completion-mode` is `minor-mode`