### PR TITLE
fix: ensure tool call UI updates when summary is missing

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1896,10 +1896,11 @@ Append STATUS, TOOL-CALL-NEXT-LINE-SPACING and ROOTS"
   "Update tool call UI for json output given CONTENT, TIME and STATUS."
   (-let* (((&plist :name name :arguments arguments :server server :details details :id
                    id :summary summary) content)
-          (jsons (plist-get details :jsons)))
+          (jsons (plist-get details :jsons))
+          (label (or summary (format "Called tool: %s__%s" server name))))
     (eca-chat--update-expandable-content
      id
-     (concat (propertize summary 'font-lock-face 'eca-chat-mcp-tool-call-label-face)
+     (concat (propertize label 'font-lock-face 'eca-chat-mcp-tool-call-label-face)
              " " status time)
      (eca-chat--content-table
       `(("Tool"   . ,name)


### PR DESCRIPTION
The tool call UI would stay in a 'waiting' state (hourglass icon) for tools that didn't provide a summary in their completion output (e.g., sequential_thinking).

This happened because `eca-chat--tool-call-json-outputs-details` attempted to use `concat` with a nil `summary` value, causing the handler to terminate silently before it could update the status icon. Adding a fallback label ensures the UI update always completes.

https://github.com/editor-code-assistant/eca-emacs/issues/99