### PR TITLE
Add use-package installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ For more details about ECA, check [ECA server](https://github.com/editor-code-as
 M-x package-install eca
 ```
 
+### Use Package
+
+```
+(use-package eca
+  :vc (:url "https://github.com/editor-code-assistant/eca-emacs" :rev :newest))
+```
+
 ### Doom Emacs:
 
 ```elisp


### PR DESCRIPTION
## Summary
- Add use-package installation instructions to the README

## Problem
Users who prefer `use-package` to manage their Emacs packages needed documentation on how to install ECA using this method.

## Solution
Added a new "Use Package" section in the README with example configuration code:

```elisp
(use-package eca
  :vc (:url "https://github.com/editor-code-assistant/eca-emacs" :rev :newest))
```

## Test plan
- [ ] Review the README changes in the diff
- [ ] Verify the use-package code example is correct

🤖 Generated with [eca](https://eca.dev)