### PR TITLE
Fix: rejecting tool-call

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -2966,21 +2966,23 @@ Must be called with `eca-chat--with-current-buffer' or equivalent."
 
 ;;;###autoload
 (defun eca-chat-tool-call-accept-next ()
-  "Search the next pending approval tool call after cursor and approve it."
+  "Search the next pending approval tool call in the buffer and approve it, starting from the beginning of the buffer."
   (interactive)
   (eca-assert-session-running (eca-session))
   (eca-chat--with-current-buffer (eca-chat--get-last-buffer (eca-session))
     (save-excursion
+      (goto-char (point-min))
       (when (text-property-search-forward 'eca-tool-call-pending-approval-accept t t)
         (call-interactively #'eca-chat--key-pressed-return)))))
 
 ;;;###autoload
 (defun eca-chat-tool-call-reject-next ()
-  "Search the next pending approval tool call after cursor and reject it."
+  "Search the next pending approval tool call in the buffer and reject it, starting from the beginning of the buffer."
   (interactive)
   (eca-assert-session-running (eca-session))
   (eca-chat--with-current-buffer (eca-chat--get-last-buffer (eca-session))
     (save-excursion
+      (goto-char (point-min))
       (when (text-property-search-forward 'eca-tool-call-pending-approval-reject t t)
         (call-interactively #'eca-chat--key-pressed-return)))))
 


### PR DESCRIPTION
## Summary 

`eca-chat-tool-call-accept-next` and `eca-chat-tool-call-reject-next` now follow the pattern of `eca-chat-tool-call-accept-all-and-remember` to first go to the beginning of the buffer and then find the corresponding text-property. 

Main reason:

- `eca-chat-tool-call-reject-next` does not work when cursor is at the end of the buffer

Note: 

- Though `eca-chat-tool-call-accept-next` was working i thought it is better to unify them

## Tests

`C-c C-r` (reject) and `C-c C-a` (approve) work when cursor is in this position 
<img width="258" height="95" alt="image" src="https://github.com/user-attachments/assets/18c8b1be-b8b1-4469-b79b-279d38741207" />
