### PR TITLE
Normalize spacing around expandable hook/reason blocks

### DIFF
--- a/eca-chat-expandable.el
+++ b/eca-chat-expandable.el
@@ -259,7 +259,9 @@ NESTED-PROPS is a plist with :parent-id and :label-indent for nested blocks."
                                   'help-echo "mouse-1 / tab / RET: expand/collapse"))
     (eca-chat--insert "\n")
     (let* ((start-point (point))
-           (ov-content (make-overlay start-point start-point (current-buffer) nil t))
+           ;; Keep zero-length content overlay stable at insertion point.
+           ;; rear-advance=nil prevents unrelated later insertions from being captured.
+           (ov-content (make-overlay start-point start-point (current-buffer) nil nil))
            (nested? (plist-get nested-props :parent-id)))
       (overlay-put ov-content 'eca-chat--expandable-content-content (propertize content 'line-prefix content-indent))
       (overlay-put ov-content 'eca-chat--expandable-block-nested nested?)

--- a/eca-chat-expandable.el
+++ b/eca-chat-expandable.el
@@ -259,7 +259,6 @@ NESTED-PROPS is a plist with :parent-id and :label-indent for nested blocks."
                                   'help-echo "mouse-1 / tab / RET: expand/collapse"))
     (eca-chat--insert "\n")
     (let* ((start-point (point))
-           (_ (eca-chat--insert "\n"))
            (ov-content (make-overlay start-point start-point (current-buffer) nil t))
            (nested? (plist-get nested-props :parent-id)))
       (overlay-put ov-content 'eca-chat--expandable-content-content (propertize content 'line-prefix content-indent))


### PR DESCRIPTION
## Summary
- remove the extra placeholder blank line inserted for newly created expandable blocks
- keep content overlay anchored at insertion point and render body only when expanded
- makes spacing between consecutive hook/reason blocks and assistant responses more consistent

Closes #92

## Notes
- Could not run local tests in this environment (`emacs`/`eask` are unavailable).
