### PR TITLE
fix: prevent `balance-windows` from resizing chat

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -3672,5 +3672,30 @@ Resteps selected message plist or nil if no messages or cancelled."
         (save-buffer))
       (eca-info (format "Saved chat to '%s'" file)))))
 
+(defun eca-chat--balance-windows-advice (orig-fn &rest args)
+  "Prevent `balance-windows' from resizing chat windows.
+Temporarily marks every live eca-chat buffer as fixed-size for
+the duration of ORIG-FN, then clears it.
+This lets `enlarge-window' and `shrink-window' still work."
+  (let (chat-bufs)
+    (dolist (buf (buffer-list))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          ;; Only fix size for chat buffers shown in a side window.
+          (when (and (derived-mode-p 'eca-chat-mode) eca-chat-use-side-window)
+            (setq-local window-size-fixed
+                        (if (memq eca-chat-window-side '(left right))
+                            'width
+                          'height))
+            (push buf chat-bufs)))))
+    (unwind-protect
+        (apply orig-fn args)
+      (dolist (buf chat-bufs)
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (setq-local window-size-fixed nil)))))))
+
+(advice-add 'balance-windows :around #'eca-chat--balance-windows-advice)
+
 (provide 'eca-chat)
 ;;; eca-chat.el ends here

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -4742,5 +4742,30 @@ Used by `eca-doctor'."
       (eca-chat--doctor-format src-buf)
     "No chat buffer found in any running session.\n"))
 
+(defun eca-chat--balance-windows-advice (orig-fn &rest args)
+  "Prevent `balance-windows' from resizing chat windows.
+Temporarily marks every live eca-chat buffer as fixed-size for
+the duration of ORIG-FN, then clears it.
+This lets `enlarge-window' and `shrink-window' still work."
+  (let (chat-bufs)
+    (dolist (buf (buffer-list))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          ;; Only fix size for chat buffers shown in a side window.
+          (when (and (derived-mode-p 'eca-chat-mode) eca-chat-use-side-window)
+            (setq-local window-size-fixed
+                        (if (memq eca-chat-window-side '(left right))
+                            'width
+                          'height))
+            (push buf chat-bufs)))))
+    (unwind-protect
+        (apply orig-fn args)
+      (dolist (buf chat-bufs)
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (setq-local window-size-fixed nil)))))))
+
+(advice-add 'balance-windows :around #'eca-chat--balance-windows-advice)
+
 (provide 'eca-chat)
 ;;; eca-chat.el ends here


### PR DESCRIPTION
As title, without this change, when running `balance-windows`, even if eca-chat window is a side window, it will try to balance it.

An alternative is to not use side window, but the implication then is, your chat constantly is resized when opening/closing buffers.

With this fix, your side window size is respected regardless of other buffers/windows.

Without hindering any other window operations.

Addresses the issue raised with https://github.com/editor-code-assistant/eca-emacs/pull/205 