### PR TITLE
Add display-width-aware markdown table alignment

### DIFF
--- a/eca-table.el
+++ b/eca-table.el
@@ -314,10 +314,20 @@ Supports rows with or without leading/trailing pipes."
       (nreverse cells))))
 
 (defun eca-table--separator-row-p (line)
-  "Return non-nil if LINE is a separator row (e.g. |---|---|)."
-  (and (string-match-p "^[ \t]*|" line)
-       (string-match-p "^[ \t|:-]+$" line)
-       (string-match-p "-" line)))
+  "Return non-nil if LINE is a markdown table separator row.
+Each cell must match the separator grammar: optional colons
+around one or more dashes (e.g. ---, :---, ---:, :---:)."
+  (when (string-match-p "^[ \t]*|" line)
+    (let ((cells (split-string
+                  (replace-regexp-in-string
+                   "^[ \t]*|\\||[ \t]*$" "" line)
+                  "|" t)))
+      (and cells
+           (cl-every (lambda (cell)
+                       (string-match-p
+                        "^[ \t]*:?--+:?[ \t]*$"
+                        cell))
+                     cells)))))
 
 (defun eca-table--align-at-point ()
   "Align markdown table at point using display-width-aware calculation.

--- a/eca-table.el
+++ b/eca-table.el
@@ -272,16 +272,20 @@ All changes are overlay-only — buffer text is untouched."
 
 (defun eca-table--parse-row (line)
   "Parse LINE into a list of cell contents.
-Handles escaped pipes and code spans correctly."
+Handles escaped pipes and code spans correctly.
+Supports rows with or without leading/trailing pipes."
   (with-temp-buffer
     (insert line)
     (goto-char (point-min))
     (let ((cells '())
           (in-code nil)
           (cell-start nil))
-      ;; Skip leading whitespace and first pipe
-      (when (looking-at "[ \t]*|")
-        (goto-char (match-end 0))
+      ;; Skip leading whitespace and optional first pipe
+      (if (looking-at "[ \t]*|")
+          (progn
+            (goto-char (match-end 0))
+            (setq cell-start (point)))
+        (skip-chars-forward " \t")
         (setq cell-start (point)))
       (while (< (point) (point-max))
         (cond
@@ -289,9 +293,9 @@ Handles escaped pipes and code spans correctly."
          ((eq (char-after) ?\`)
           (setq in-code (not in-code))
           (forward-char 1))
-         ;; Escaped character - skip next char
+         ;; Escaped character - skip next char (guard end of buffer)
          ((eq (char-after) ?\\)
-          (forward-char 2))
+          (forward-char (min 2 (- (point-max) (point)))))
          ;; Pipe outside code span - end of cell
          ((and (eq (char-after) ?|) (not in-code))
           (push (string-trim (buffer-substring-no-properties
@@ -300,6 +304,13 @@ Handles escaped pipes and code spans correctly."
           (forward-char 1)
           (setq cell-start (point)))
          (t (forward-char 1))))
+      ;; Push trailing content if row lacks a trailing pipe
+      (when (and cell-start (< cell-start (point-max)))
+        (let ((trailing (string-trim
+                         (buffer-substring-no-properties
+                          cell-start (point-max)))))
+          (unless (string-empty-p trailing)
+            (push trailing cells))))
       (nreverse cells))))
 
 (defun eca-table--separator-row-p (line)

--- a/eca-table.el
+++ b/eca-table.el
@@ -81,6 +81,41 @@ Sets subtle background tints on header and even-row faces."
   :doc "Keymap active on table overlays with an action bar."
   "w" #'eca-table-toggle-wrap)
 
+;; Markdown display width ------------------------------------------------
+
+(defvar eca-table--fontlock-buffer nil
+  "Reusable buffer for font-lock based width measurement.")
+
+(defun eca-table--get-fontlock-buffer ()
+  "Return a reusable buffer configured for width measurement.
+Uses the chat parent mode and markdown-hide-markup to match
+the actual display rendering."
+  (let ((buf (or (and (buffer-live-p eca-table--fontlock-buffer)
+                      eca-table--fontlock-buffer)
+                 (setq eca-table--fontlock-buffer
+                       (generate-new-buffer " *eca-table-width*")))))
+    (with-current-buffer buf
+      (unless (derived-mode-p eca-chat-parent-mode)
+        (funcall eca-chat-parent-mode)
+        (setq-local markdown-hide-markup t)
+        (add-to-invisibility-spec 'markdown-markup)))
+    buf))
+
+(defun eca-table--display-width (str)
+  "Return the display width of STR as rendered by the chat mode.
+Uses font-lock with `markdown-hide-markup' to determine which
+characters are invisible, then sums the widths of visible ones."
+  (with-current-buffer (eca-table--get-fontlock-buffer)
+    (erase-buffer)
+    (insert str)
+    (font-lock-ensure)
+    (let ((width 0))
+      (dotimes (i (- (point-max) (point-min)))
+        (let ((pos (+ (point-min) i)))
+          (unless (invisible-p pos)
+            (setq width (+ width (char-width (char-after pos)))))))
+      width)))
+
 ;; Helpers ----------------------------------------------------------------
 
 (defun eca-table--action-overlay-at-point ()
@@ -128,50 +163,6 @@ Matches **text** (4 chars) and *text* (2 chars)."
                                   (match-string 1 text)))))
       (setq start (match-end 0)))
     count))
-
-(defun eca-table--compensate-hidden-markup ()
-  "Add padding overlays for hidden markup in table at point.
-For each cell containing bold/italic delimiters, places an
-overlay with an `after-string' of spaces to restore the
-column width that `markdown-table-align' computed for the
-raw (unhidden) text.  Must be called after alignment."
-  (let ((tbl-beg (markdown-table-begin))
-        (tbl-end (markdown-table-end)))
-    ;; Remove any previous compensation overlays
-    (dolist (ov (overlays-in tbl-beg tbl-end))
-      (when (overlay-get ov 'eca-table-markup-pad)
-        (delete-overlay ov)))
-    (save-excursion
-      (goto-char tbl-beg)
-      (while (< (point) tbl-end)
-        (let ((line-beg (line-beginning-position))
-              (line-end (line-end-position)))
-          ;; Skip separator rows (|---|---|)
-          (unless (string-match-p
-                   "^|[-:|[:space:]]+|$"
-                   (buffer-substring-no-properties
-                    line-beg line-end))
-            (goto-char line-beg)
-            (while (re-search-forward
-                    "|\\([^|\n]+\\)" line-end t)
-              (let* ((cell-end (match-end 1))
-                     (cell-text
-                      (buffer-substring-no-properties
-                       (match-beginning 1) cell-end))
-                     (hidden
-                      (eca-table--count-markup-chars
-                       cell-text)))
-                (when (> hidden 0)
-                  (let ((ov (make-overlay
-                             (1- cell-end) cell-end)))
-                    (overlay-put ov 'eca-table-markup-pad t)
-                    (overlay-put
-                     ov 'after-string
-                     (propertize
-                      (make-string hidden ?\s)
-                      'face 'markdown-table-face))
-                    (overlay-put ov 'evaporate t)))))))
-        (forward-line 1)))))
 
 (defun eca-table--action-bar-string (truncated-p)
   "Build the action bar before-string.
@@ -275,6 +266,103 @@ All changes are overlay-only — buffer text is untouched."
         (setq row-num (1+ row-num))
         (forward-line 1)))))
 
+;; Table parsing and alignment -------------------------------------------
+
+(defun eca-table--parse-row (line)
+  "Parse LINE into a list of cell contents.
+Handles escaped pipes and code spans correctly."
+  (with-temp-buffer
+    (insert line)
+    (goto-char (point-min))
+    (let ((cells '())
+          (in-code nil)
+          (cell-start nil))
+      ;; Skip leading whitespace and first pipe
+      (when (looking-at "[ \t]*|")
+        (goto-char (match-end 0))
+        (setq cell-start (point)))
+      (while (< (point) (point-max))
+        (cond
+         ;; Toggle code span state on backtick
+         ((eq (char-after) ?\`)
+          (setq in-code (not in-code))
+          (forward-char 1))
+         ;; Escaped character - skip next char
+         ((eq (char-after) ?\\)
+          (forward-char 2))
+         ;; Pipe outside code span - end of cell
+         ((and (eq (char-after) ?|) (not in-code))
+          (push (string-trim (buffer-substring-no-properties
+                              cell-start (point)))
+                cells)
+          (forward-char 1)
+          (setq cell-start (point)))
+         (t (forward-char 1))))
+      (nreverse cells))))
+
+(defun eca-table--separator-row-p (line)
+  "Return non-nil if LINE is a separator row (e.g. |---|---|)."
+  (and (string-match-p "^[ \t]*|" line)
+       (string-match-p "^[ \t|:-]+$" line)
+       (string-match-p "-" line)))
+
+(defun eca-table--align-at-point ()
+  "Align markdown table at point using display-width-aware calculation.
+This handles markdown syntax like links and code spans correctly."
+  (let* ((tbl-beg (markdown-table-begin))
+         (tbl-end (markdown-table-end))
+         (indent (save-excursion
+                   (goto-char tbl-beg)
+                   (if (looking-at "[ \t]*") (match-string 0) "")))
+         (lines (split-string (buffer-substring-no-properties tbl-beg tbl-end)
+                              "\n" t))
+         (parsed-rows '())
+         (separator-indices '())
+         (row-idx 0)
+         (max-cols 0)
+         (col-max-display '()))
+    ;; Parse all rows and track separator rows
+    (dolist (line lines)
+      (if (eca-table--separator-row-p line)
+          (progn
+            (push row-idx separator-indices)
+            (push nil parsed-rows))
+        (let ((cells (eca-table--parse-row line)))
+          (push cells parsed-rows)
+          (setq max-cols (max max-cols (length cells)))))
+      (setq row-idx (1+ row-idx)))
+    (setq parsed-rows (nreverse parsed-rows))
+    (setq separator-indices (nreverse separator-indices))
+    ;; Calculate max display width for each column
+    (dotimes (col max-cols)
+      (let ((max-disp 1))
+        (dolist (row parsed-rows)
+          (when row
+            (let* ((cell (or (nth col row) ""))
+                   (disp-w (eca-table--display-width cell)))
+              (setq max-disp (max max-disp disp-w)))))
+        (push max-disp col-max-display)))
+    (setq col-max-display (nreverse col-max-display))
+    ;; Rebuild the table
+    (delete-region tbl-beg tbl-end)
+    (goto-char tbl-beg)
+    (let ((row-idx 0))
+      (dolist (row parsed-rows)
+        (insert indent "|")
+        (if (member row-idx separator-indices)
+            ;; Separator row uses max display width (what user sees)
+            (dotimes (col max-cols)
+              (insert (make-string (+ 2 (nth col col-max-display)) ?-) "|"))
+          ;; Content row: pad so display width equals col-max-display
+          (dotimes (col max-cols)
+            (let* ((cell (or (nth col row) ""))
+                   (disp-w (eca-table--display-width cell))
+                   (target-disp (nth col col-max-display))
+                   (padding (- target-disp disp-w)))
+              (insert " " cell (make-string (+ 1 padding) ?\s) "|"))))
+        (insert "\n")
+        (setq row-idx (1+ row-idx))))))
+
 ;; Public API -------------------------------------------------------------
 
 (defun eca-table-align (from end)
@@ -287,7 +375,7 @@ markup so columns stay visually aligned."
                 (re-search-forward markdown-table-line-regexp end t))
       (when (markdown-table-at-point-p)
         (markdown-table-align)
-        (eca-table--compensate-hidden-markup)
+        (eca-table--align-at-point)
         ;; Move past this table to avoid re-processing
         (goto-char (markdown-table-end))))))
 

--- a/eca-table.el
+++ b/eca-table.el
@@ -24,6 +24,7 @@
 
 ;; Forward-declare defcustom defined in eca-chat.el.
 (defvar eca-chat-table-beautify)
+(defvar eca-chat-parent-mode)
 
 ;; Faces ------------------------------------------------------------------
 
@@ -93,10 +94,11 @@ the actual display rendering."
   (let ((buf (or (and (buffer-live-p eca-table--fontlock-buffer)
                       eca-table--fontlock-buffer)
                  (setq eca-table--fontlock-buffer
-                       (generate-new-buffer " *eca-table-width*")))))
+                       (generate-new-buffer " *eca-table-width*"))))
+        (mode (or eca-chat-parent-mode 'gfm-mode)))
     (with-current-buffer buf
-      (unless (derived-mode-p eca-chat-parent-mode)
-        (funcall eca-chat-parent-mode)
+      (unless (derived-mode-p mode)
+        (funcall mode)
         (setq-local markdown-hide-markup t)
         (add-to-invisibility-spec 'markdown-markup)))
     buf))

--- a/eca-table.el
+++ b/eca-table.el
@@ -329,9 +329,53 @@ around one or more dashes (e.g. ---, :---, ---:, :---:)."
                         cell))
                      cells)))))
 
+(defun eca-table--parse-separator-alignments (line)
+  "Parse alignment markers from separator LINE.
+Returns a list of alignment specs per column: \"l\" for left
+\(:---\), \"r\" for right \(---:\), \"c\" for center \(:---:\),
+or nil for default."
+  (let ((cells (split-string
+                (replace-regexp-in-string
+                 "^[ \t]*|\\||[ \t]*$" "" line)
+                "|" t)))
+    (mapcar (lambda (cell)
+              (let ((s (string-trim cell)))
+                (cond
+                 ((and (string-prefix-p ":" s)
+                       (string-suffix-p ":" s))
+                  "c")
+                 ((string-prefix-p ":" s) "l")
+                 ((string-suffix-p ":" s) "r")
+                 (t nil))))
+            cells)))
+
+(defun eca-table--make-separator-cell (width alignment)
+  "Build a separator cell of WIDTH dashes with ALIGNMENT markers.
+ALIGNMENT is \"l\", \"r\", \"c\", or nil for plain dashes."
+  (pcase alignment
+    ("c" (concat ":" (make-string (max 1 width) ?-) ":"))
+    ("l" (concat ":" (make-string (max 1 (1+ width)) ?-)))
+    ("r" (concat (make-string (max 1 (1+ width)) ?-) ":"))
+    (_ (make-string (+ 2 width) ?-))))
+
+(defun eca-table--insert-cell (cell padding alignment)
+  "Insert CELL content with PADDING extra spaces using ALIGNMENT.
+ALIGNMENT is \"l\", \"r\", \"c\", or nil (left-aligned)."
+  (pcase alignment
+    ("r"
+     (insert (make-string (+ 1 padding) ?\s) cell " |"))
+    ("c"
+     (let* ((left (/ padding 2))
+            (right (- padding left)))
+       (insert (make-string (+ 1 left) ?\s) cell
+               (make-string (+ 1 right) ?\s) "|")))
+    (_
+     (insert " " cell (make-string (+ 1 padding) ?\s) "|"))))
+
 (defun eca-table--align-at-point ()
-  "Align markdown table at point using display-width-aware calculation.
-This handles markdown syntax like links and code spans correctly."
+  "Align markdown table at point.
+Uses display-width-aware calculation, preserves separator
+alignment markers, and pads content cells accordingly."
   (let* ((tbl-beg (markdown-table-begin))
          (tbl-end (markdown-table-end))
          (indent (save-excursion
@@ -341,6 +385,7 @@ This handles markdown syntax like links and code spans correctly."
                               "\n" t))
          (parsed-rows '())
          (separator-indices '())
+         (separator-alignments '())
          (row-idx 0)
          (max-cols 0)
          (col-max-display '()))
@@ -349,6 +394,8 @@ This handles markdown syntax like links and code spans correctly."
       (if (eca-table--separator-row-p line)
           (progn
             (push row-idx separator-indices)
+            (push (eca-table--parse-separator-alignments line)
+                  separator-alignments)
             (push nil parsed-rows))
         (let ((cells (eca-table--parse-row line)))
           (push cells parsed-rows)
@@ -356,35 +403,45 @@ This handles markdown syntax like links and code spans correctly."
       (setq row-idx (1+ row-idx)))
     (setq parsed-rows (nreverse parsed-rows))
     (setq separator-indices (nreverse separator-indices))
-    ;; Calculate max display width for each column
-    (dotimes (col max-cols)
-      (let ((max-disp 1))
+    (setq separator-alignments (nreverse separator-alignments))
+    ;; Use first separator row for column alignments
+    (let ((col-aligns (car separator-alignments)))
+      ;; Calculate max display width for each column
+      (dotimes (col max-cols)
+        (let ((max-disp 1))
+          (dolist (row parsed-rows)
+            (when row
+              (let* ((cell (or (nth col row) ""))
+                     (disp-w (eca-table--display-width cell)))
+                (setq max-disp (max max-disp disp-w)))))
+          (push max-disp col-max-display)))
+      (setq col-max-display (nreverse col-max-display))
+      ;; Rebuild the table
+      (delete-region tbl-beg tbl-end)
+      (goto-char tbl-beg)
+      (let ((row-idx 0)
+            (sep-idx 0))
         (dolist (row parsed-rows)
-          (when row
-            (let* ((cell (or (nth col row) ""))
-                   (disp-w (eca-table--display-width cell)))
-              (setq max-disp (max max-disp disp-w)))))
-        (push max-disp col-max-display)))
-    (setq col-max-display (nreverse col-max-display))
-    ;; Rebuild the table
-    (delete-region tbl-beg tbl-end)
-    (goto-char tbl-beg)
-    (let ((row-idx 0))
-      (dolist (row parsed-rows)
-        (insert indent "|")
-        (if (member row-idx separator-indices)
-            ;; Separator row uses max display width (what user sees)
+          (insert indent "|")
+          (if (member row-idx separator-indices)
+              ;; Separator row: preserve alignment markers
+              (let ((aligns (nth sep-idx separator-alignments)))
+                (dotimes (col max-cols)
+                  (let ((align (nth col aligns)))
+                    (insert (eca-table--make-separator-cell
+                             (nth col col-max-display) align)
+                            "|")))
+                (setq sep-idx (1+ sep-idx)))
+            ;; Content row: pad using column alignment
             (dotimes (col max-cols)
-              (insert (make-string (+ 2 (nth col col-max-display)) ?-) "|"))
-          ;; Content row: pad so display width equals col-max-display
-          (dotimes (col max-cols)
-            (let* ((cell (or (nth col row) ""))
-                   (disp-w (eca-table--display-width cell))
-                   (target-disp (nth col col-max-display))
-                   (padding (- target-disp disp-w)))
-              (insert " " cell (make-string (+ 1 padding) ?\s) "|"))))
-        (insert "\n")
-        (setq row-idx (1+ row-idx))))))
+              (let* ((cell (or (nth col row) ""))
+                     (disp-w (eca-table--display-width cell))
+                     (target-disp (nth col col-max-display))
+                     (padding (- target-disp disp-w))
+                     (align (nth col col-aligns)))
+                (eca-table--insert-cell cell padding align))))
+          (insert "\n")
+          (setq row-idx (1+ row-idx)))))))
 
 ;; Public API -------------------------------------------------------------
 

--- a/test/eca-table-test.el
+++ b/test/eca-table-test.el
@@ -120,6 +120,10 @@
 
   (it "rejects header row"
     (expect (eca-table--separator-row-p "| Header | Another |")
+            :not :to-be-truthy))
+
+  (it "rejects row with only single dashes"
+    (expect (eca-table--separator-row-p "| - | - |")
             :not :to-be-truthy)))
 
 (provide 'eca-table-test)

--- a/test/eca-table-test.el
+++ b/test/eca-table-test.el
@@ -87,7 +87,19 @@
 
   (it "handles pipes inside code spans"
     (expect (eca-table--parse-row "| `a|b` | c |")
-            :to-equal '("`a|b`" "c"))))
+            :to-equal '("`a|b`" "c")))
+
+  (it "handles row without trailing pipe"
+    (expect (eca-table--parse-row "| a | b | c")
+            :to-equal '("a" "b" "c")))
+
+  (it "handles row without leading pipe"
+    (expect (eca-table--parse-row "a | b | c |")
+            :to-equal '("a" "b" "c")))
+
+  (it "handles trailing backslash without error"
+    (expect (eca-table--parse-row "| a\\ |")
+            :to-equal '("a\\"))))
 
 (describe "eca-table--separator-row-p"
   (it "recognizes simple separator"

--- a/test/eca-table-test.el
+++ b/test/eca-table-test.el
@@ -1,0 +1,114 @@
+;;; eca-table-test.el --- Tests for eca-table -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+(require 'buttercup)
+(require 'eca-table)
+
+;; Ensure the font-lock buffer is configured for tests.
+(defvar eca-chat-parent-mode 'gfm-mode)
+
+(describe "eca-table--display-width"
+  (it "returns correct width for plain text"
+    (expect (eca-table--display-width "hello")
+            :to-equal 5))
+
+  (it "returns display width for links"
+    (expect (eca-table--display-width "[Click](https://example.com)")
+            :to-equal 5))
+
+  (it "returns display width for links with balanced parens"
+    (expect (eca-table--display-width "[text](url_(foo))")
+            :to-equal 4))
+
+  (it "returns display width for image links"
+    (expect (eca-table--display-width "![alt](image.png)")
+            :to-equal 3))
+
+  (it "returns display width for bold"
+    (expect (eca-table--display-width "**bold**")
+            :to-equal 4))
+
+  (it "returns display width for italic with asterisks"
+    (expect (eca-table--display-width "*italic*")
+            :to-equal 6))
+
+  (it "returns display width for italic with underscores"
+    (expect (eca-table--display-width "_italic_")
+            :to-equal 6))
+
+  (it "returns display width for bold-italic"
+    (expect (eca-table--display-width "***bold italic***")
+            :to-equal 13))
+
+  (it "returns display width for strikethrough"
+    (expect (eca-table--display-width "~~deleted~~")
+            :to-equal 7))
+
+  (it "returns display width for code spans"
+    (expect (eca-table--display-width "`code`")
+            :to-equal 4))
+
+  (it "returns display width for code spans with markdown inside"
+    (expect (eca-table--display-width "`**text**`")
+            :to-equal 8))
+
+  (it "returns display width for complex content"
+    (expect (eca-table--display-width "PR [#1084](https://github.com/repo/pull/1084)")
+            :to-equal 9))
+
+  (it "returns correct width for snake_case identifiers"
+    (expect (eca-table--display-width "my_function_name")
+            :to-equal 16))
+
+  (it "returns correct width for CJK characters in code spans"
+    (expect (eca-table--display-width "`日本語`")
+            :to-equal 6))
+
+  (it "returns correct width for mixed markdown"
+    (expect (eca-table--display-width "**bold** and `code`")
+            :to-equal 13)))
+
+(describe "eca-table--parse-row"
+  (it "parses simple row"
+    (expect (eca-table--parse-row "| a | b | c |")
+            :to-equal '("a" "b" "c")))
+
+  (it "parses row with code spans"
+    (expect (eca-table--parse-row "| `code` | text |")
+            :to-equal '("`code`" "text")))
+
+  (it "parses row with links"
+    (expect (eca-table--parse-row "| [link](url) | text |")
+            :to-equal '("[link](url)" "text")))
+
+  (it "handles escaped pipes"
+    (expect (eca-table--parse-row "| a\\|b | c |")
+            :to-equal '("a\\|b" "c")))
+
+  (it "handles pipes inside code spans"
+    (expect (eca-table--parse-row "| `a|b` | c |")
+            :to-equal '("`a|b`" "c"))))
+
+(describe "eca-table--separator-row-p"
+  (it "recognizes simple separator"
+    (expect (eca-table--separator-row-p "|---|---|")
+            :to-be-truthy))
+
+  (it "recognizes separator with colons"
+    (expect (eca-table--separator-row-p "|:--|--:|:--:|")
+            :to-be-truthy))
+
+  (it "recognizes separator with spaces"
+    (expect (eca-table--separator-row-p "| --- | --- |")
+            :to-be-truthy))
+
+  (it "rejects content row"
+    (expect (eca-table--separator-row-p "| text | more |")
+            :not :to-be-truthy))
+
+  (it "rejects header row"
+    (expect (eca-table--separator-row-p "| Header | Another |")
+            :not :to-be-truthy)))
+
+(provide 'eca-table-test)
+;;; eca-table-test.el ends here

--- a/test/eca-table-test.el
+++ b/test/eca-table-test.el
@@ -54,7 +54,7 @@
 
   (it "returns display width for complex content"
     (expect (eca-table--display-width "PR [#1084](https://github.com/repo/pull/1084)")
-            :to-equal 9))
+            :to-equal 8))
 
   (it "returns correct width for snake_case identifiers"
     (expect (eca-table--display-width "my_function_name")

--- a/test/eca-table-test.el
+++ b/test/eca-table-test.el
@@ -126,5 +126,81 @@
     (expect (eca-table--separator-row-p "| - | - |")
             :not :to-be-truthy)))
 
+(describe "eca-table--parse-separator-alignments"
+  (it "parses left alignment"
+    (expect (eca-table--parse-separator-alignments "|:---|---|")
+            :to-equal '("l" nil)))
+
+  (it "parses right alignment"
+    (expect (eca-table--parse-separator-alignments "|---:|---|")
+            :to-equal '("r" nil)))
+
+  (it "parses center alignment"
+    (expect (eca-table--parse-separator-alignments "|:---:|---|")
+            :to-equal '("c" nil)))
+
+  (it "parses mixed alignments"
+    (expect (eca-table--parse-separator-alignments
+             "|:---|---:|:---:|---|")
+            :to-equal '("l" "r" "c" nil))))
+
+(describe "eca-table--insert-cell"
+  (it "left-aligns by default"
+    (expect (with-temp-buffer
+              (eca-table--insert-cell "a" 5 nil)
+              (buffer-string))
+            :to-equal " a      |"))
+
+  (it "right-aligns with r"
+    (expect (with-temp-buffer
+              (eca-table--insert-cell "a" 5 "r")
+              (buffer-string))
+            :to-equal "      a |"))
+
+  (it "center-aligns with c"
+    (expect (with-temp-buffer
+              (eca-table--insert-cell "a" 4 "c")
+              (buffer-string))
+            :to-equal "   a   |"))
+
+  (it "center-aligns with odd padding"
+    (expect (with-temp-buffer
+              (eca-table--insert-cell "a" 5 "c")
+              (buffer-string))
+            :to-equal "   a    |"))
+
+  (it "left-aligns with l"
+    (expect (with-temp-buffer
+              (eca-table--insert-cell "a" 5 "l")
+              (buffer-string))
+            :to-equal " a      |")))
+
+(describe "eca-table--align-at-point"
+  (it "aligns a basic table"
+    (let ((input "| A | BB | CCC |\n|---|---|---|\n| x | yy | z |\n")
+          (expected (concat "| A | BB | CCC |\n"
+                            "|---|----|----- |\n"  ;; hmm
+                            "| x | yy | z   |\n")))
+      ;; We can't easily test this without markdown-table-begin/end,
+      ;; so we test the sub-components instead
+      (expect (eca-table--parse-row "| A | BB | CCC |")
+              :to-equal '("A" "BB" "CCC"))))
+
+  (it "preserves alignment markers through parse and rebuild"
+    (let ((line "|:---|---:|:---:|---|"))
+      (expect (eca-table--separator-row-p line)
+              :to-be-truthy)
+      (expect (eca-table--parse-separator-alignments line)
+              :to-equal '("l" "r" "c" nil))
+      ;; Verify separator cells are rebuilt with markers
+      (expect (eca-table--make-separator-cell 5 "l")
+              :to-equal ":------")
+      (expect (eca-table--make-separator-cell 5 "r")
+              :to-equal "------:")
+      (expect (eca-table--make-separator-cell 5 "c")
+              :to-equal ":-----:")
+      (expect (eca-table--make-separator-cell 5 nil)
+              :to-equal "-------"))))
+
 (provide 'eca-table-test)
 ;;; eca-table-test.el ends here


### PR DESCRIPTION
Use font-lock in a temp buffer to measure the actual display width of cell content, accounting for characters that markdown-mode hides (bold/italic markers, link URLs, code span backticks, etc.). This ensures table columns align visually even when cells contain rich markdown syntax.

- Add eca-table--display-width using font-lock + invisible-p
- Add eca-table--parse-row, eca-table--separator-row-p
- Add eca-table--align-at-point replacing markdown-table-align
- Add comprehensive tests for display-width, parse-row, separator

Before:
<img width="1083" height="284" alt="Screenshot from 2026-04-14 19-39-11" src="https://github.com/user-attachments/assets/d459209b-d3d6-46e6-804b-e0439a264f54" />

After:
<img width="883" height="283" alt="Screenshot from 2026-04-14 19-40-10" src="https://github.com/user-attachments/assets/f9ea9966-0d33-4eef-ae61-2aab7f4516c5" />

