### PR TITLE
fix(diagnostics): eglot with flycheck vs flymake

### DIFF
--- a/eca-editor.el
+++ b/eca-editor.el
@@ -54,6 +54,16 @@
     ((or 'flymake-note ':note 'eglot-note) "information")
     (_ "unknown")))
 
+(defun eca-editor--flycheck-active-in-locus-p (locus)
+  "Return non-nil if LOCUS is a live buffer with `flycheck-mode' on.
+Used to suppress flymake diagnostics for buffers where flycheck is
+already the active diagnostic surface, mirroring how the flycheck
+branch suppresses its own output in lsp-managed buffers.  The
+resulting precedence is: lsp-mode > flycheck > flymake."
+  (and (buffer-live-p locus)
+       (with-current-buffer locus
+         (bound-and-true-p flycheck-mode))))
+
 (defun eca-editor--flycheck-to-eca-severity (level)
   "Convert flycheck LEVEL to eca severity."
   (pcase level
@@ -111,7 +121,8 @@ If URI is nil find all diagnostics otherwise filter to that uri."
             (diag-uri (eca--path-to-uri file-path))
             (beg (flymake-diagnostic-beg it))
             (end (flymake-diagnostic-end it)))
-       (when (or (null uri) (string= uri diag-uri))
+       (when (and (or (null uri) (string= uri diag-uri))
+                  (not (eca-editor--flycheck-active-in-locus-p locus)))
          (let ((range (if buffer-p
                           (with-current-buffer locus
                             (save-excursion

--- a/test/eca-editor-test.el
+++ b/test/eca-editor-test.el
@@ -1,0 +1,45 @@
+;;; eca-editor-test.el --- Tests for eca-editor -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'buttercup)
+(require 'eca-editor)
+
+;; Forward declaration so byte-compilation does not warn when flycheck
+;; is not installed in the test environment.
+(defvar flycheck-mode)
+
+(describe "eca-editor--flycheck-active-in-locus-p"
+  (it "returns nil for a nil locus"
+    (expect (eca-editor--flycheck-active-in-locus-p nil)
+            :not :to-be-truthy))
+
+  (it "returns nil for a file-path (string) locus"
+    (expect (eca-editor--flycheck-active-in-locus-p "/tmp/foo.el")
+            :not :to-be-truthy))
+
+  (it "returns nil for a killed buffer"
+    (let ((buf (generate-new-buffer " *eca-editor-test-killed*")))
+      (kill-buffer buf)
+      (expect (eca-editor--flycheck-active-in-locus-p buf)
+              :not :to-be-truthy)))
+
+  (it "returns nil for a live buffer where flycheck-mode is unset"
+    (with-temp-buffer
+      (expect (eca-editor--flycheck-active-in-locus-p (current-buffer))
+              :not :to-be-truthy)))
+
+  (it "returns nil for a live buffer where flycheck-mode is nil"
+    (with-temp-buffer
+      (setq-local flycheck-mode nil)
+      (expect (eca-editor--flycheck-active-in-locus-p (current-buffer))
+              :not :to-be-truthy)))
+
+  (it "returns non-nil for a live buffer where flycheck-mode is t"
+    (with-temp-buffer
+      (setq-local flycheck-mode t)
+      (expect (eca-editor--flycheck-active-in-locus-p (current-buffer))
+              :to-be-truthy))))
+
+(provide 'eca-editor-test)
+;;; eca-editor-test.el ends here


### PR DESCRIPTION
The `editor_diagnostics` failed with _Symbol's function definition is void: flymake-diagnostic-code_ and it happens when running eglot + **flycheck** (no lsp-mode).

Suggested solution:
checking if flycheck is the active tool used before running the flymake diagnostics.

Current workaround in my Emacs setup:
```elisp
(with-eval-after-load 'eca-editor
  (defun eca-editor--flymake-diagnostics (_uri _workspace)
    "Neutralized: flycheck-eglot already bridges eglot diagnostics into flycheck."
    nil))
```

Note: the changes in this PR were created by Eca with the Opus 4.7 model -  with me steering. I am not confident in my Elisp skills as I am in Python, though.