### PR TITLE
Fix weird deletion behavior

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1217,6 +1217,7 @@ This is similar to actions like `backward-delete-char' but protects
 the prompt/context line."
   (if (derived-mode-p 'eca-chat-mode)
       (let* ((cur-ov (car (overlays-in (line-beginning-position) (line-end-position))))
+             (prompt-ov (eca-chat--prompt-field-ov))
              (text (thing-at-point 'symbol))
              (in-prompt? (eca-chat--point-at-prompt-field-p))
              (context-item (-some->> text
@@ -1248,10 +1249,11 @@ the prompt/context line."
           (apply side-effect-fn args))
 
          ;; start of the prompt
-         ((and cur-ov
-               (or (<= (point) (overlay-start cur-ov))
+         ((and prompt-ov
+               (or (<= (point) (overlay-start prompt-ov))
                    (and (eq 'backward-kill-word this-command)
-                        (string-blank-p (buffer-substring-no-properties (line-beginning-position) (point))))))
+                        (string-blank-p (buffer-substring-no-properties
+                                         (overlay-start prompt-ov) (point))))))
           (ding))
 
          ;; in context area trying to remove a context space separator

--- a/test/eca-chat-test.el
+++ b/test/eca-chat-test.el
@@ -1,0 +1,90 @@
+;;; eca-chat-test.el --- Tests for eca-chat -*- lexical-binding: t; -*-
+;;; Commentary:
+;; Tests for `eca-chat--key-pressed-deletion' prompt boundary logic.
+;;; Code:
+(require 'buttercup)
+(require 'eca-chat)
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defun eca-chat-test--make-prompt-buffer (prompt-text)
+  "Create a test buffer with PROMPT-TEXT in a simulated prompt.
+Returns the buffer.  Caller must kill it."
+  (let ((buf (generate-new-buffer " *test-chat-deletion*")))
+    (with-current-buffer buf
+      ;; Simulate content above the prompt
+      (insert "header\n---\n@\n\n")
+      (let ((prompt-start (point)))
+        (insert prompt-text)
+        ;; 1-char prompt-field overlay, matching real layout
+        (let ((ov (make-overlay prompt-start (1+ prompt-start))))
+          (overlay-put ov 'eca-chat-prompt-field t)))
+      (setq major-mode 'eca-chat-mode))
+    buf))
+
+(defun eca-chat-test--prompt-text (buf)
+  "Return the prompt field text from BUF."
+  (with-current-buffer buf
+    (buffer-substring-no-properties
+     (eca-chat--prompt-field-start-point) (point-max))))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(describe "eca-chat--key-pressed-deletion"
+
+  (describe "multi-line prompt"
+
+    (it "deletes newline at beginning of second line"
+      (let ((buf (eca-chat-test--make-prompt-buffer "hello\nfooo")))
+        (unwind-protect
+            (with-current-buffer buf
+              (goto-char (eca-chat--prompt-field-start-point))
+              (forward-line 1)
+              (let ((this-command 'backward-delete-char))
+                (eca-chat--key-pressed-deletion
+                 (lambda (n &optional _) (delete-char (- n)))
+                 1))
+              (expect (eca-chat-test--prompt-text buf)
+                      :to-equal "hellofooo"))
+          (kill-buffer buf))))
+
+    (it "deletes newline even with non-prompt overlays on line"
+      (let ((buf (eca-chat-test--make-prompt-buffer "hello\nfooo")))
+        (unwind-protect
+            (with-current-buffer buf
+              (goto-char (eca-chat--prompt-field-start-point))
+              (forward-line 1)
+              ;; Simulate an hl-line-like overlay on this line
+              (make-overlay (line-beginning-position)
+                            (line-end-position))
+              (let ((this-command 'backward-delete-char))
+                (eca-chat--key-pressed-deletion
+                 (lambda (n &optional _) (delete-char (- n)))
+                 1))
+              (expect (eca-chat-test--prompt-text buf)
+                      :to-equal "hellofooo"))
+          (kill-buffer buf)))))
+
+  (describe "prompt boundary"
+
+    (it "blocks deletion at prompt field start"
+      (let ((buf (eca-chat-test--make-prompt-buffer "hello")))
+        (unwind-protect
+            (with-current-buffer buf
+              (goto-char (eca-chat--prompt-field-start-point))
+              (let ((this-command 'backward-delete-char)
+                    (side-effect-called nil))
+                (cl-letf (((symbol-function 'ding) #'ignore))
+                  (eca-chat--key-pressed-deletion
+                   (lambda (&rest _) (setq side-effect-called t))
+                   1))
+                (expect side-effect-called :to-be nil)
+                (expect (eca-chat-test--prompt-text buf)
+                        :to-equal "hello")))
+          (kill-buffer buf))))))
+
+;;; eca-chat-test.el ends here


### PR DESCRIPTION
Sometimes I get it into a state where `<backspace>` refuses to move the caret. e.g. when something gets pushed to a new line like in:

```
Aliquam feugiat ut neque

|tellus

   aliquam posuere
```

If the point is at the beginning of the line (right in front of "tellus") backspace won't delete, moving the caret to the back of "neque" (as it normally should)
