### PR TITLE
Add path remapping for remote ECA servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,4 @@
 - docstrings should have 80 chars or less, otherwise emacs built-in diagnostics complains.
 - We should support emacs 28.1+
+- Tests are written with buttercup.
+- Tests are ran on macos, windows & ubuntu latest.

--- a/eca-chat-context.el
+++ b/eca-chat-context.el
@@ -23,6 +23,7 @@
 (defvar eca-chat-window-width)
 (declare-function eca-chat--insert "eca-chat")
 (declare-function eca-chat--prompt-field-start-point "eca-chat")
+(declare-function eca-chat--refine-context "eca-chat")
 (declare-function eca-chat--prompt-context-field-ov "eca-chat")
 (declare-function eca-chat--point-at-new-context-p "eca-chat")
 (declare-function eca-chat--point-at-prompt-field-p "eca-chat")
@@ -599,7 +600,8 @@ Calls CB with the resulting message."
                                                                                :method "chat/queryContext"
                                                                                :params (list :chatId eca-chat--id
                                                                                              :query query
-                                                                                             :contexts (vconcat eca-chat--context))))
+                                                                                             :contexts (vconcat (mapcar #'eca-chat--refine-context
+                                                                      eca-chat--context)))))
                                                  (items (-map #'eca-chat--context-to-completion contexts)))
                                            (clrhash eca-chat--context-completion-cache)
                                            (puthash query items eca-chat--context-completion-cache)

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1322,9 +1322,14 @@ the prompt/context line."
              (expanded-str (get-text-property pos 'eca-chat-expanded-item-str prompt))
              (item-type (get-text-property pos 'eca-chat-item-type prompt)))
         (if expanded-str
-            (setq result (concat result (if (eq 'filepath item-type)
-                                            (eca--path-local-to-remote (substring expanded-str 1))
-                                          expanded-str)))
+            (setq result (concat result
+                                 (cond
+                                  ((eq item-type 'filepath)
+                                   (eca--path-local-to-remote (substring expanded-str 1)))
+                                  ((eq item-type 'context)
+                                   (concat "@" (eca--path-local-to-remote
+                                                (substring expanded-str 1))))
+                                  (t expanded-str))))
           (setq result (concat result (substring prompt pos next-change))))
         (setq pos next-change)))
     result))
@@ -1497,7 +1502,7 @@ the prompt-field overlay's start advances past inserted content."
   (eca-api-notify session
                   :method "chat/promptSteer"
                   :params (list :chatId eca-chat--id
-                                :message prompt)))
+                                :message (eca-chat--normalize-prompt prompt))))
 
 (defun eca-chat--send-steered-prompt (session)
   "Merge any unconsumed steered prompt into the queued prompt for SESSION.

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1300,11 +1300,16 @@ the prompt/context line."
 
 (defun eca-chat--refine-context (context)
   "Refine CONTEXT before sending in prompt."
-  (pcase (plist-get context :type)
-    ("cursor" (-> context
-                  (plist-put :path (plist-get eca-chat--cursor-context :path))
-                  (plist-put :position (plist-get eca-chat--cursor-context :position))))
-    (_ context)))
+  (let* ((type (plist-get context :type))
+         (refined (pcase type
+                    ("cursor" (-> context
+                                  (plist-put :path (plist-get eca-chat--cursor-context :path))
+                                  (plist-put :position (plist-get eca-chat--cursor-context :position))))
+                    (_ context)))
+         (path (plist-get refined :path)))
+    (if path
+        (plist-put (copy-sequence refined) :path (eca--path-local-to-remote path))
+      refined)))
 
 (defun eca-chat--normalize-prompt (prompt)
   "Normalize PROMPT before sending to server.
@@ -1318,7 +1323,7 @@ the prompt/context line."
              (item-type (get-text-property pos 'eca-chat-item-type prompt)))
         (if expanded-str
             (setq result (concat result (if (eq 'filepath item-type)
-                                            (substring expanded-str 1)
+                                            (eca--path-local-to-remote (substring expanded-str 1))
                                           expanded-str)))
           (setq result (concat result (substring prompt pos next-change))))
         (setq pos next-change)))
@@ -2533,7 +2538,7 @@ CONTENT is the tool call content, LABEL is the label.
 Can include optional APPROVAL-TEXT and TIME.
 Append STATUS, ROOTS and optional PARENT-ID."
   (-let* (((&plist :name name :details details :id id) content)
-          (path (plist-get details :path))
+          (path (eca--path-remote-to-local (plist-get details :path)))
           (diff (plist-get details :diff))
           (view-diff-btn
            (when (and path diff)
@@ -2545,7 +2550,7 @@ Append STATUS, ROOTS and optional PARENT-ID."
     (eca-chat--update-expandable-content
      id
      (concat (propertize label 'font-lock-face 'eca-chat-mcp-tool-call-label-face)
-             " " (eca-chat--file-change-details-label details)
+             " " (eca-chat--file-change-details-label (plist-put (copy-sequence details) :path path))
              " " status time
              (when view-diff-btn
                (concat " " view-diff-btn))

--- a/eca-completion.el
+++ b/eca-completion.el
@@ -304,6 +304,7 @@ Call ON-ERROR when error."
                              :method "completion/inline"
                              :params (list :doc-text (buffer-substring-no-properties (point-min) (point-max))
                                            :doc-version eca-completion--doc-version
+                                           :path (eca--path-local-to-remote (buffer-file-name))
                                            :position (list :line line :character character))
                              :success-callback (-lambda ((&plist :items items :error error))
                                                  (if error

--- a/eca-rewrite.el
+++ b/eca-rewrite.el
@@ -402,14 +402,15 @@ PATH is the optional file path."
         (end-char (save-excursion
                     (goto-char end)
                     (current-column)))
-        (id (number-to-string (random 100000000))))
+        (id (number-to-string (random 100000000)))
+        (remote-path (when path (eca--path-local-to-remote path))))
     (eca-api-request-async
      session
      :method "rewrite/prompt"
      :params (list :id id
                    :text text
                    :prompt prompt
-                   :path path
+                   :path remote-path
                    :range (list :start (list :line start-line :character start-char)
                                 :end (list :line end-line :character end-char)))
      :success-callback

--- a/eca-util.el
+++ b/eca-util.el
@@ -331,40 +331,66 @@ workspace folder. Falls back to \"unknown\"."
 
 (defcustom eca-path-mappings nil
   "Alist mapping local file paths to remote/container server paths.
-This is useful when the ECA server is running inside a Docker container.
-Format is an alist of (LOCAL-PATH . REMOTE-PATH).
+This is useful when the ECA server is running inside a Docker
+container or on a remote machine with a different filesystem
+layout.  Format is an alist of (LOCAL-PATH . REMOTE-PATH).
 
-Example:
-  '((\"/Users/me/dev/project\" . \"/workspace/project\"))"
+The most specific (longest) matching prefix is used, so a single
+parent-directory mapping eliminates the need for per-project
+entries in the common Docker/container case:
+
+  \\='((\"/Users/me/dev\" . \"/workspace\"))
+  ;; /Users/me/dev/project-a → /workspace/project-a
+  ;; /Users/me/dev/project-b → /workspace/project-b
+
+If a project needs a different remote path, add a more specific
+entry that takes precedence:
+
+  \\='((\"/Users/me/dev\" . \"/workspace\")
+    (\"/Users/me/dev/special\" . \"/custom\"))
+  ;; /Users/me/dev/project → /workspace/project
+  ;; /Users/me/dev/special → /custom"
   :type '(alist :key-type string :value-type string)
   :group 'eca)
 
+(defun eca--path--translate (path from-fn to-fn expand-from-p)
+  "Translate PATH using `eca-path-mappings'.
+FROM-FN extracts the side of each mapping to match against PATH;
+TO-FN extracts the side to substitute in.  The longest matching
+prefix wins; ties break on the opposite side's length."
+  (let ((sorted (sort (copy-sequence eca-path-mappings)
+                      (lambda (a b)
+                        (let ((la (length (funcall from-fn a)))
+                              (lb (length (funcall from-fn b))))
+                          (if (= la lb)
+                              (> (length (funcall to-fn a))
+                                 (length (funcall to-fn b)))
+                            (> la lb)))))))
+    (or (seq-some
+         (lambda (m)
+           (let* ((from-raw (funcall from-fn m))
+                  (to-raw (funcall to-fn m))
+                  (from (file-name-as-directory
+                         (if expand-from-p (expand-file-name from-raw) from-raw)))
+                  (to (file-name-as-directory
+                       (if (not expand-from-p) (expand-file-name to-raw) to-raw))))
+             (cond
+              ((string= path (directory-file-name from))
+               (directory-file-name to))
+              ((string-prefix-p from path)
+               (concat to (substring path (length from)))))))
+         sorted)
+        path)))
+
 (defun eca--path-local-to-remote (path)
-  "Translate a local Emacs PATH to a remote path using `eca-path-mappings'."
-  (let ((expanded (expand-file-name path)))
-    (or (seq-some (lambda (mapping)
-                    (let* ((local-dir (file-name-as-directory (expand-file-name (car mapping))))
-                           (remote-dir (file-name-as-directory (cdr mapping))))
-                      (cond
-                       ((string= expanded (directory-file-name local-dir))
-                        (directory-file-name remote-dir))
-                       ((string-prefix-p local-dir expanded)
-                        (concat remote-dir (substring expanded (length local-dir)))))))
-                  eca-path-mappings)
-        expanded)))
+  "Translate a local Emacs PATH to a remote path using `eca-path-mappings'.
+Uses the longest (most specific) matching prefix to avoid ambiguity."
+  (eca--path--translate (expand-file-name path) #'car #'cdr t))
 
 (defun eca--path-remote-to-local (path)
-  "Translate a remote server PATH to a local Emacs path using `eca-path-mappings'."
-  (or (seq-some (lambda (mapping)
-                  (let* ((local-dir (file-name-as-directory (expand-file-name (car mapping))))
-                         (remote-dir (file-name-as-directory (cdr mapping))))
-                    (cond
-                     ((string= path (directory-file-name remote-dir))
-                      (directory-file-name local-dir))
-                     ((string-prefix-p remote-dir path)
-                      (concat local-dir (substring path (length remote-dir)))))))
-                eca-path-mappings)
-      path))
+  "Translate a remote server PATH to a local Emacs path using `eca-path-mappings'.
+Uses the longest (most specific) matching prefix to avoid ambiguity."
+  (eca--path--translate path #'cdr #'car nil))
 
 (defun eca-info (format &rest args)
   "Display eca info message with FORMAT with ARGS."

--- a/eca-util.el
+++ b/eca-util.el
@@ -329,7 +329,7 @@ workspace folder. Falls back to \"unknown\"."
                (t uri))))
     (eca--path-remote-to-local path)))
 
-(defcustom eca-path-mappings nil
+(defcustom eca-local-to-remote-prefix-map nil
   "Alist of (LOCAL-PATH . REMOTE-PATH) for Docker or remote servers.
 The longest matching prefix wins.
 
@@ -341,12 +341,12 @@ The longest matching prefix wins.
   :group 'eca)
 
 (defun eca--path--translate (path from-fn to-fn expand-from-p)
-  "Translate PATH using `eca-path-mappings'.
+  "Translate PATH using `eca-local-to-remote-prefix-map'.
 FROM-FN extracts the side of each mapping to match against PATH;
 TO-FN extracts the side to substitute in.  If EXPAND-FROM-P is non-nil,
 expand the from-side path.  The longest matching prefix wins."
   (let* ((ensure-slash (lambda (s) (if (string-suffix-p "/" s) s (concat s "/"))))
-         (sorted (sort (copy-sequence eca-path-mappings)
+         (sorted (sort (copy-sequence eca-local-to-remote-prefix-map)
                        (lambda (a b)
                          (let ((la (length (funcall from-fn a)))
                                (lb (length (funcall from-fn b))))
@@ -371,12 +371,12 @@ expand the from-side path.  The longest matching prefix wins."
         path)))
 
 (defun eca--path-local-to-remote (path)
-  "Translate a local Emacs PATH to a remote path using `eca-path-mappings'.
+  "Translate a local Emacs PATH to a remote path using `eca-local-to-remote-prefix-map'.
 Uses the longest (most specific) matching prefix to avoid ambiguity."
   (eca--path--translate (expand-file-name path) #'car #'cdr t))
 
 (defun eca--path-remote-to-local (path)
-  "Translate a remote server PATH to a local Emacs path using `eca-path-mappings'.
+  "Translate a remote server PATH to a local Emacs path using `eca-local-to-remote-prefix-map'.
 Uses the longest (most specific) matching prefix to avoid ambiguity."
   (eca--path--translate path #'cdr #'car nil))
 

--- a/eca-util.el
+++ b/eca-util.el
@@ -330,21 +330,8 @@ workspace folder. Falls back to \"unknown\"."
     (eca--path-remote-to-local path)))
 
 (defcustom eca-path-mappings nil
-  "Alist mapping local file paths to remote/container server paths.
-This is useful when the ECA server is running inside a Docker
-container or on a remote machine with a different filesystem
-layout.  Format is an alist of (LOCAL-PATH . REMOTE-PATH).
-
-The most specific (longest) matching prefix is used, so a single
-parent-directory mapping eliminates the need for per-project
-entries in the common Docker/container case:
-
-  \\='((\"/Users/me/dev\" . \"/workspace\"))
-  ;; /Users/me/dev/project-a → /workspace/project-a
-  ;; /Users/me/dev/project-b → /workspace/project-b
-
-If a project needs a different remote path, add a more specific
-entry that takes precedence:
+  "Alist of (LOCAL-PATH . REMOTE-PATH) for Docker or remote servers.
+The longest matching prefix wins.
 
   \\='((\"/Users/me/dev\" . \"/workspace\")
     (\"/Users/me/dev/special\" . \"/custom\"))
@@ -356,8 +343,8 @@ entry that takes precedence:
 (defun eca--path--translate (path from-fn to-fn expand-from-p)
   "Translate PATH using `eca-path-mappings'.
 FROM-FN extracts the side of each mapping to match against PATH;
-TO-FN extracts the side to substitute in.  The longest matching
-prefix wins; ties break on the opposite side's length."
+TO-FN extracts the side to substitute in.  If EXPAND-FROM-P is non-nil,
+expand the from-side path.  The longest matching prefix wins."
   (let ((sorted (sort (copy-sequence eca-path-mappings)
                       (lambda (a b)
                         (let ((la (length (funcall from-fn a)))

--- a/eca-util.el
+++ b/eca-util.el
@@ -345,22 +345,23 @@ The longest matching prefix wins.
 FROM-FN extracts the side of each mapping to match against PATH;
 TO-FN extracts the side to substitute in.  If EXPAND-FROM-P is non-nil,
 expand the from-side path.  The longest matching prefix wins."
-  (let ((sorted (sort (copy-sequence eca-path-mappings)
-                      (lambda (a b)
-                        (let ((la (length (funcall from-fn a)))
-                              (lb (length (funcall from-fn b))))
-                          (if (= la lb)
-                              (> (length (funcall to-fn a))
-                                 (length (funcall to-fn b)))
-                            (> la lb)))))))
+  (let* ((ensure-slash (lambda (s) (if (string-suffix-p "/" s) s (concat s "/"))))
+         (sorted (sort (copy-sequence eca-path-mappings)
+                       (lambda (a b)
+                         (let ((la (length (funcall from-fn a)))
+                               (lb (length (funcall from-fn b))))
+                           (if (= la lb)
+                               (> (length (funcall to-fn a))
+                                  (length (funcall to-fn b)))
+                             (> la lb)))))))
     (or (seq-some
          (lambda (m)
            (let* ((from-raw (funcall from-fn m))
                   (to-raw (funcall to-fn m))
-                  (from (file-name-as-directory
-                         (if expand-from-p (expand-file-name from-raw) from-raw)))
-                  (to (file-name-as-directory
-                       (if (not expand-from-p) (expand-file-name to-raw) to-raw))))
+                  (from (funcall ensure-slash
+                                 (if expand-from-p (expand-file-name from-raw) from-raw)))
+                  (to (funcall ensure-slash
+                               (if (not expand-from-p) (expand-file-name to-raw) to-raw))))
              (cond
               ((string= path (directory-file-name from))
                (directory-file-name to))

--- a/eca-util.el
+++ b/eca-util.el
@@ -41,7 +41,7 @@
   all scope to the individual worktree.  This matches the behaviour
   prior to 0.110.0 and is preferred for parallel worktree workflows."
   :type '(choice (const :tag "Merged (shared session per repo)" merged)
-                 (const :tag "Isolated (independent session per worktree)" isolated))
+          (const :tag "Isolated (independent session per worktree)" isolated))
   :group 'eca)
 
 (defun eca-uuid ()
@@ -329,7 +329,15 @@ workspace folder. Falls back to \"unknown\"."
                (t uri))))
     (eca--path-remote-to-local path)))
 
-(defvar eca-path-mappings)
+(defcustom eca-path-mappings nil
+  "Alist mapping local file paths to remote/container server paths.
+This is useful when the ECA server is running inside a Docker container.
+Format is an alist of (LOCAL-PATH . REMOTE-PATH).
+
+Example:
+  '((\"/Users/me/dev/project\" . \"/workspace/project\"))"
+  :type '(alist :key-type string :value-type string)
+  :group 'eca)
 
 (defun eca--path-local-to-remote (path)
   "Translate a local Emacs PATH to a remote path using `eca-path-mappings'."

--- a/eca-util.el
+++ b/eca-util.el
@@ -222,8 +222,8 @@ nil otherwise."
        :method "workspace/didChangeWorkspaceFolders"
        :params (list :event
                      (list :added (vector
-                                  (list :uri (eca--path-to-uri folder)
-                                        :name (file-name-nondirectory (directory-file-name folder))))
+                                   (list :uri (eca--path-to-uri folder)
+                                         :name (file-name-nondirectory (directory-file-name folder))))
                            :removed [])))
       (eca-info "Added workspace folder: %s" folder))))
 
@@ -313,19 +313,50 @@ workspace folder. Falls back to \"unknown\"."
   (concat eca--uri-file-prefix
           (--> path
                (expand-file-name it)
-               (or (file-remote-p it 'localname t) it))))
+               (or (file-remote-p it 'localname t) it)
+               (eca--path-local-to-remote it))))
 
 (defun eca--uri-to-path (uri)
   "Convert a file URI to a file path."
-  (cond
-   ((string-prefix-p "file:///" uri)
-    (url-unhex-string
-     (substring uri (if (eq system-type 'windows-nt) 8 7))))
+  (let ((path (cond
+               ((string-prefix-p "file:///" uri)
+                (url-unhex-string
+                 (substring uri (if (eq system-type 'windows-nt) 8 7))))
 
-   ((string-prefix-p "file://" uri)
-    (url-unhex-string (substring uri 6)))
+               ((string-prefix-p "file://" uri)
+                (url-unhex-string (substring uri 6)))
 
-   (t uri)))
+               (t uri))))
+    (eca--path-remote-to-local path)))
+
+(defvar eca-path-mappings)
+
+(defun eca--path-local-to-remote (path)
+  "Translate a local Emacs PATH to a remote path using `eca-path-mappings'."
+  (let ((expanded (expand-file-name path)))
+    (or (seq-some (lambda (mapping)
+                    (let* ((local-dir (file-name-as-directory (expand-file-name (car mapping))))
+                           (remote-dir (file-name-as-directory (cdr mapping))))
+                      (cond
+                       ((string= expanded (directory-file-name local-dir))
+                        (directory-file-name remote-dir))
+                       ((string-prefix-p local-dir expanded)
+                        (concat remote-dir (substring expanded (length local-dir)))))))
+                  eca-path-mappings)
+        expanded)))
+
+(defun eca--path-remote-to-local (path)
+  "Translate a remote server PATH to a local Emacs path using `eca-path-mappings'."
+  (or (seq-some (lambda (mapping)
+                  (let* ((local-dir (file-name-as-directory (expand-file-name (car mapping))))
+                         (remote-dir (file-name-as-directory (cdr mapping))))
+                    (cond
+                     ((string= path (directory-file-name remote-dir))
+                      (directory-file-name local-dir))
+                     ((string-prefix-p remote-dir path)
+                      (concat local-dir (substring path (length remote-dir)))))))
+                eca-path-mappings)
+      path))
 
 (defun eca-info (format &rest args)
   "Display eca info message with FORMAT with ARGS."

--- a/test/eca-chat-test.el
+++ b/test/eca-chat-test.el
@@ -87,4 +87,57 @@ Returns the buffer.  Caller must kill it."
                         :to-equal "hello")))
           (kill-buffer buf))))))
 
+(describe "eca-chat path mapping"
+  (describe "chat/queryContext"
+    (it "maps paths in :contexts to remote"
+      (let ((eca-chat--id "chat-123")
+            (eca-chat--context '((:type "file" :path "/local/path/file.txt")))
+            (session (make-eca--session)))
+        (spy-on 'eca-session :and-return-value session)
+        (spy-on 'eca--session-workspace-folders :and-return-value '("/local/path"))
+        (spy-on 'eca--path-local-to-remote :and-return-value "/remote/path/file.txt")
+        (spy-on 'eca-api-request-while-no-input :and-return-value '(:contexts []))
+        (spy-on 'eca-chat--find-typed-query :and-return-value "")
+        (spy-on 'eca-chat--point-at-new-context-p :and-return-value nil)
+        (with-temp-buffer
+          (insert "@")
+          (let* ((capf-res (eca-chat-completion-at-point))
+                 (completion-fn (nth 2 capf-res)))
+            (funcall completion-fn "" nil t)
+            (expect 'eca--path-local-to-remote :to-have-been-called-with "/local/path/file.txt")
+            (expect 'eca-api-request-while-no-input :to-have-been-called-with
+                    session
+                    :method "chat/queryContext"
+                    :params (list :chatId "chat-123"
+                                  :query ""
+                                  :contexts [(:type "file" :path "/remote/path/file.txt")])))))))
+
+  (describe "chat/promptSteer"
+    (it "normalizes the message prompt"
+      (let ((eca-chat--id "chat-456")
+            (session (make-eca--session)))
+        (spy-on 'eca-api-notify)
+        (spy-on 'eca--path-local-to-remote :and-return-value "/remote/path/file.txt")
+        (let ((prompt (propertize "@file.txt"
+                                  'eca-chat-expanded-item-str "@file.txt"
+                                  'eca-chat-item-type 'context)))
+          (eca-chat--steer-prompt session prompt)
+          (expect 'eca--path-local-to-remote :to-have-been-called-with "file.txt")
+          (expect 'eca-api-notify :to-have-been-called-with
+                  session
+                  :method "chat/promptSteer"
+                  :params (list :chatId "chat-456"
+                                :message "@/remote/path/file.txt"))))))
+
+  (describe "eca-chat--normalize-prompt"
+    (it "handles relative paths in expansions"
+      (let ((default-directory "/local/path/"))
+        (spy-on 'eca--path-local-to-remote :and-return-value "/remote/path/file.txt")
+        (let ((prompt (propertize "@file.txt"
+                                  'eca-chat-expanded-item-str "@file.txt"
+                                  'eca-chat-item-type 'context)))
+          (expect (eca-chat--normalize-prompt prompt)
+                  :to-equal "@/remote/path/file.txt")
+          (expect 'eca--path-local-to-remote :to-have-been-called-with "file.txt"))))))
+
 ;;; eca-chat-test.el ends here

--- a/test/eca-completion-test.el
+++ b/test/eca-completion-test.el
@@ -105,5 +105,23 @@ Falls back to the `default' face's foreground when none is set."
       ;; original (unparseable) value or default fallback.
       (expect dimmed :to-equal src))))
 
+(describe "eca-completion path mapping"
+  (describe "completion/inline"
+    (it "sends mapped :path in params"
+      (let ((session (make-eca--session)))
+        (spy-on 'eca-session :and-return-value session)
+        (spy-on 'eca-api-request-async)
+        (spy-on 'eca--path-local-to-remote :and-return-value "/remote/path/src/main.rs")
+        (with-temp-buffer
+          (setq-local buffer-file-name "/local/path/src/main.rs")
+          (eca-completion--find-completion :on-success #'ignore :on-error #'ignore)
+          (expect 'eca--path-local-to-remote :to-have-been-called-with "/local/path/src/main.rs")
+          (expect 'eca-api-request-async :to-have-been-called)
+          (let* ((args (spy-calls-args-for 'eca-api-request-async 0))
+                 (params (plist-get (cdr args) :params)))
+            (expect (plist-get (cdr args) :method) :to-equal "completion/inline")
+            (expect (plist-get params :path) :to-equal "/remote/path/src/main.rs")
+            (expect (plist-get params :doc-text) :to-equal "")))))))
+
 (provide 'eca-completion-test)
 ;;; eca-completion-test.el ends here

--- a/test/eca-util-test.el
+++ b/test/eca-util-test.el
@@ -13,11 +13,27 @@
       (expect (eca--path-local-to-remote "/Users/me/dev/project/src/main.rs")
               :to-equal "/workspace/project/src/main.rs")))
 
-  (it "translates using the first matching mapping"
-    (let ((eca-path-mappings '(("/Users/me/other" . "/opt/other")
-                               ("/Users/me/dev/project" . "/workspace/project"))))
+  (it "translates using the longest (most specific) matching mapping"
+    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+                               ("/Users/me/dev/project" . "/custom"))))
       (expect (eca--path-local-to-remote "/Users/me/dev/project/package.json")
-              :to-equal "/workspace/project/package.json")))
+              :to-equal "/custom/package.json")))
+
+  (it "longest-prefix wins regardless of order"
+    ;; General mapping first, specific override second.
+    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+                               ("/Users/me/dev/special" . "/custom"))))
+      (expect (eca--path-local-to-remote "/Users/me/dev/special/src/main.rs")
+              :to-equal "/custom/src/main.rs")
+      (expect (eca--path-local-to-remote "/Users/me/dev/other/src/main.rs")
+              :to-equal "/workspace/other/src/main.rs"))
+    ;; Specific override first, general mapping second.
+    (let ((eca-path-mappings '(("/Users/me/dev/special" . "/custom")
+                               ("/Users/me/dev" . "/workspace"))))
+      (expect (eca--path-local-to-remote "/Users/me/dev/special/src/main.rs")
+              :to-equal "/custom/src/main.rs")
+      (expect (eca--path-local-to-remote "/Users/me/dev/other/src/main.rs")
+              :to-equal "/workspace/other/src/main.rs")))
 
   (it "returns the expanded local path if no mapping matches"
     (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
@@ -35,11 +51,27 @@
       (expect (eca--path-remote-to-local "/workspace/project/src/main.rs")
               :to-equal "/Users/me/dev/project/src/main.rs")))
 
-  (it "translates using the first match"
-    (let ((eca-path-mappings '(("/Users/me/other" . "/opt/other")
-                               ("/Users/me/dev/project" . "/workspace/project"))))
-      (expect (eca--path-remote-to-local "/workspace/project/package.json")
+  (it "translates using the longest (most specific) matching mapping"
+    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+                               ("/Users/me/dev/project" . "/custom"))))
+      (expect (eca--path-remote-to-local "/custom/package.json")
               :to-equal "/Users/me/dev/project/package.json")))
+
+  (it "longest-prefix wins regardless of order"
+    ;; General mapping first, specific override second.
+    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+                               ("/Users/me/dev/special" . "/custom"))))
+      (expect (eca--path-remote-to-local "/custom/src/main.rs")
+              :to-equal "/Users/me/dev/special/src/main.rs")
+      (expect (eca--path-remote-to-local "/workspace/other/src/main.rs")
+              :to-equal "/Users/me/dev/other/src/main.rs"))
+    ;; Specific override first, general mapping second.
+    (let ((eca-path-mappings '(("/Users/me/dev/special" . "/custom")
+                               ("/Users/me/dev" . "/workspace"))))
+      (expect (eca--path-remote-to-local "/custom/src/main.rs")
+              :to-equal "/Users/me/dev/special/src/main.rs")
+      (expect (eca--path-remote-to-local "/workspace/other/src/main.rs")
+              :to-equal "/Users/me/dev/other/src/main.rs")))
 
   (it "returns the inputted path when no match is found"
     (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
@@ -70,6 +102,30 @@
     (let ((eca-path-mappings '(("/Users/me/project/" . "/workspace/project/"))))
       (expect (eca--path-local-to-remote "/Users/me/project/src")
               :to-equal "/workspace/project/src"))))
+
+(describe "eca--path-local-to-remote nested"
+  (it "handles nested local paths mapping to the same remote path"
+    (let ((eca-path-mappings '(("/Users/me/ws/nested" . "/workspace")
+                               ("/Users/me/ws/nested/dev" . "/workspace"))))
+      (expect (eca--path-local-to-remote "/Users/me/ws/nested/dev/project/file.el")
+              :to-equal "/workspace/project/file.el")
+      (expect (eca--path-local-to-remote "/Users/me/ws/nested/other/file.el")
+              :to-equal "/workspace/other/file.el"))))
+
+(describe "eca--path-remote-to-local nested"
+  (it "handles nested local paths mapping to the same remote path"
+    (let ((eca-path-mappings '(("/Users/me/ws/nested" . "/workspace")
+                               ("/Users/me/ws/nested/dev" . "/workspace"))))
+      (expect (eca--path-remote-to-local "/workspace/project/file.el")
+              :to-equal "/Users/me/ws/nested/dev/project/file.el"))))
+
+(describe "eca--path-translation windows"
+  (it "handles Windows paths correctly"
+    (let ((eca-path-mappings '(("C:/Users/me/ws/win-project" . "/workspace/win-project"))))
+      (expect (eca--path-local-to-remote "C:/Users/me/ws/win-project/src/main.rs")
+              :to-equal "/workspace/win-project/src/main.rs")
+      (expect (eca--path-remote-to-local "/workspace/win-project/src/main.rs")
+              :to-equal (expand-file-name "C:/Users/me/ws/win-project/src/main.rs")))))
 
 (provide 'eca-util-test)
 ;;; eca-util-test.el ends here

--- a/test/eca-util-test.el
+++ b/test/eca-util-test.el
@@ -49,29 +49,29 @@
   (it "translates a remote path to a local path"
     (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
       (expect (eca--path-remote-to-local "/workspace/project/src/main.rs")
-              :to-equal "/Users/me/dev/project/src/main.rs")))
+              :to-equal (expand-file-name "/Users/me/dev/project/src/main.rs"))))
 
   (it "translates using the longest (most specific) matching mapping"
     (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/project" . "/custom"))))
       (expect (eca--path-remote-to-local "/custom/package.json")
-              :to-equal "/Users/me/dev/project/package.json")))
+              :to-equal (expand-file-name "/Users/me/dev/project/package.json"))))
 
   (it "longest-prefix wins regardless of order"
     ;; General mapping first, specific override second.
     (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/special" . "/custom"))))
       (expect (eca--path-remote-to-local "/custom/src/main.rs")
-              :to-equal "/Users/me/dev/special/src/main.rs")
+              :to-equal (expand-file-name "/Users/me/dev/special/src/main.rs"))
       (expect (eca--path-remote-to-local "/workspace/other/src/main.rs")
-              :to-equal "/Users/me/dev/other/src/main.rs"))
+              :to-equal (expand-file-name "/Users/me/dev/other/src/main.rs")))
     ;; Specific override first, general mapping second.
     (let ((eca-path-mappings '(("/Users/me/dev/special" . "/custom")
                                ("/Users/me/dev" . "/workspace"))))
       (expect (eca--path-remote-to-local "/custom/src/main.rs")
-              :to-equal "/Users/me/dev/special/src/main.rs")
+              :to-equal (expand-file-name "/Users/me/dev/special/src/main.rs"))
       (expect (eca--path-remote-to-local "/workspace/other/src/main.rs")
-              :to-equal "/Users/me/dev/other/src/main.rs")))
+              :to-equal (expand-file-name "/Users/me/dev/other/src/main.rs"))))
 
   (it "returns the inputted path when no match is found"
     (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
@@ -81,7 +81,7 @@
   (it "handles paths with trailing slashes"
     (let ((eca-path-mappings '(("/home/user/app/" . "/app/"))))
       (expect (eca--path-remote-to-local "/app/src/index.js")
-              :to-equal "/home/user/app/src/index.js")))
+              :to-equal (expand-file-name "/home/user/app/src/index.js"))))
 
   (it "does not match substrings"
     (let ((eca-path-mappings '(("/Users/me/project" . "/workspace/project"))))
@@ -117,7 +117,7 @@
     (let ((eca-path-mappings '(("/Users/me/ws/nested" . "/workspace")
                                ("/Users/me/ws/nested/dev" . "/workspace"))))
       (expect (eca--path-remote-to-local "/workspace/project/file.el")
-              :to-equal "/Users/me/ws/nested/dev/project/file.el"))))
+              :to-equal (expand-file-name "/Users/me/ws/nested/dev/project/file.el")))))
 
 (describe "eca--path-translation windows"
   (it "handles Windows paths correctly"

--- a/test/eca-util-test.el
+++ b/test/eca-util-test.el
@@ -1,0 +1,75 @@
+;;; eca-util-test.el --- Tests for eca-util -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'buttercup)
+(require 'eca-util)
+
+(defvar eca-path-mappings)
+
+(describe "eca--path-local-to-remote"
+  (it "translates a mapped local path to a remote path"
+    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-local-to-remote "/Users/me/dev/project/src/main.rs")
+              :to-equal "/workspace/project/src/main.rs")))
+
+  (it "translates using the first matching mapping"
+    (let ((eca-path-mappings '(("/Users/me/other" . "/opt/other")
+                               ("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-local-to-remote "/Users/me/dev/project/package.json")
+              :to-equal "/workspace/project/package.json")))
+
+  (it "returns the expanded local path if no mapping matches"
+    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-local-to-remote "/Users/me/unmapped-dir/file.txt")
+              :to-equal (expand-file-name "/Users/me/unmapped-dir/file.txt"))))
+
+  (it "handles paths with trailing slashes correctly"
+    (let ((eca-path-mappings '(("/home/user/app/" . "/app/"))))
+      (expect (eca--path-local-to-remote "/home/user/app/src/index.js")
+              :to-equal "/app/src/index.js"))))
+
+(describe "eca--path-remote-to-local"
+  (it "translates a remote path to a local path"
+    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-remote-to-local "/workspace/project/src/main.rs")
+              :to-equal "/Users/me/dev/project/src/main.rs")))
+
+  (it "translates using the first match"
+    (let ((eca-path-mappings '(("/Users/me/other" . "/opt/other")
+                               ("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-remote-to-local "/workspace/project/package.json")
+              :to-equal "/Users/me/dev/project/package.json")))
+
+  (it "returns the inputted path when no match is found"
+    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+      (expect (eca--path-remote-to-local "/unmapped/container/path/file.txt")
+              :to-equal "/unmapped/container/path/file.txt")))
+
+  (it "handles paths with trailing slashes"
+    (let ((eca-path-mappings '(("/home/user/app/" . "/app/"))))
+      (expect (eca--path-remote-to-local "/app/src/index.js")
+              :to-equal "/home/user/app/src/index.js")))
+
+  (it "does not match substrings"
+    (let ((eca-path-mappings '(("/Users/me/project" . "/workspace/project"))))
+      (expect (eca--path-local-to-remote "/Users/me/project-api/file.txt")
+              :to-equal (expand-file-name "/Users/me/project-api/file.txt"))))
+
+  (it "preserves trailing slashes"
+    (let ((eca-path-mappings '(("/Users/me/project" . "/workspace/project"))))
+      (expect (eca--path-local-to-remote "/Users/me/project/")
+              :to-equal "/workspace/project/")
+      (expect (eca--path-local-to-remote "/Users/me/project")
+              :to-equal "/workspace/project")
+      (expect (eca--path-remote-to-local "/workspace/project/")
+              :to-equal (expand-file-name "/Users/me/project/"))))
+
+  (it "normalizes user trailing slashes in the configuration mappings"
+    ;; User puts messy trailing slashes in the mapping list
+    (let ((eca-path-mappings '(("/Users/me/project/" . "/workspace/project/"))))
+      (expect (eca--path-local-to-remote "/Users/me/project/src")
+              :to-equal "/workspace/project/src"))))
+
+(provide 'eca-util-test)
+;;; eca-util-test.el ends here

--- a/test/eca-util-test.el
+++ b/test/eca-util-test.el
@@ -5,30 +5,30 @@
 (require 'buttercup)
 (require 'eca-util)
 
-(defvar eca-path-mappings)
+(defvar eca-local-to-remote-prefix-map)
 
 (describe "eca--path-local-to-remote"
   (it "translates a mapped local path to a remote path"
-    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/project" . "/workspace/project"))))
       (expect (eca--path-local-to-remote "/Users/me/dev/project/src/main.rs")
               :to-equal "/workspace/project/src/main.rs")))
 
   (it "translates using the longest (most specific) matching mapping"
-    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/project" . "/custom"))))
       (expect (eca--path-local-to-remote "/Users/me/dev/project/package.json")
               :to-equal "/custom/package.json")))
 
   (it "longest-prefix wins regardless of order"
     ;; General mapping first, specific override second.
-    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/special" . "/custom"))))
       (expect (eca--path-local-to-remote "/Users/me/dev/special/src/main.rs")
               :to-equal "/custom/src/main.rs")
       (expect (eca--path-local-to-remote "/Users/me/dev/other/src/main.rs")
               :to-equal "/workspace/other/src/main.rs"))
     ;; Specific override first, general mapping second.
-    (let ((eca-path-mappings '(("/Users/me/dev/special" . "/custom")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/special" . "/custom")
                                ("/Users/me/dev" . "/workspace"))))
       (expect (eca--path-local-to-remote "/Users/me/dev/special/src/main.rs")
               :to-equal "/custom/src/main.rs")
@@ -36,37 +36,37 @@
               :to-equal "/workspace/other/src/main.rs")))
 
   (it "returns the expanded local path if no mapping matches"
-    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/project" . "/workspace/project"))))
       (expect (eca--path-local-to-remote "/Users/me/unmapped-dir/file.txt")
               :to-equal (expand-file-name "/Users/me/unmapped-dir/file.txt"))))
 
   (it "handles paths with trailing slashes correctly"
-    (let ((eca-path-mappings '(("/home/user/app/" . "/app/"))))
+    (let ((eca-local-to-remote-prefix-map '(("/home/user/app/" . "/app/"))))
       (expect (eca--path-local-to-remote "/home/user/app/src/index.js")
               :to-equal "/app/src/index.js"))))
 
 (describe "eca--path-remote-to-local"
   (it "translates a remote path to a local path"
-    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/project" . "/workspace/project"))))
       (expect (eca--path-remote-to-local "/workspace/project/src/main.rs")
               :to-equal (expand-file-name "/Users/me/dev/project/src/main.rs"))))
 
   (it "translates using the longest (most specific) matching mapping"
-    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/project" . "/custom"))))
       (expect (eca--path-remote-to-local "/custom/package.json")
               :to-equal (expand-file-name "/Users/me/dev/project/package.json"))))
 
   (it "longest-prefix wins regardless of order"
     ;; General mapping first, specific override second.
-    (let ((eca-path-mappings '(("/Users/me/dev" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev" . "/workspace")
                                ("/Users/me/dev/special" . "/custom"))))
       (expect (eca--path-remote-to-local "/custom/src/main.rs")
               :to-equal (expand-file-name "/Users/me/dev/special/src/main.rs"))
       (expect (eca--path-remote-to-local "/workspace/other/src/main.rs")
               :to-equal (expand-file-name "/Users/me/dev/other/src/main.rs")))
     ;; Specific override first, general mapping second.
-    (let ((eca-path-mappings '(("/Users/me/dev/special" . "/custom")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/special" . "/custom")
                                ("/Users/me/dev" . "/workspace"))))
       (expect (eca--path-remote-to-local "/custom/src/main.rs")
               :to-equal (expand-file-name "/Users/me/dev/special/src/main.rs"))
@@ -74,22 +74,22 @@
               :to-equal (expand-file-name "/Users/me/dev/other/src/main.rs"))))
 
   (it "returns the inputted path when no match is found"
-    (let ((eca-path-mappings '(("/Users/me/dev/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/dev/project" . "/workspace/project"))))
       (expect (eca--path-remote-to-local "/unmapped/container/path/file.txt")
               :to-equal "/unmapped/container/path/file.txt")))
 
   (it "handles paths with trailing slashes"
-    (let ((eca-path-mappings '(("/home/user/app/" . "/app/"))))
+    (let ((eca-local-to-remote-prefix-map '(("/home/user/app/" . "/app/"))))
       (expect (eca--path-remote-to-local "/app/src/index.js")
               :to-equal (expand-file-name "/home/user/app/src/index.js"))))
 
   (it "does not match substrings"
-    (let ((eca-path-mappings '(("/Users/me/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/project" . "/workspace/project"))))
       (expect (eca--path-local-to-remote "/Users/me/project-api/file.txt")
               :to-equal (expand-file-name "/Users/me/project-api/file.txt"))))
 
   (it "preserves trailing slashes"
-    (let ((eca-path-mappings '(("/Users/me/project" . "/workspace/project"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/project" . "/workspace/project"))))
       (expect (eca--path-local-to-remote "/Users/me/project/")
               :to-equal "/workspace/project/")
       (expect (eca--path-local-to-remote "/Users/me/project")
@@ -99,13 +99,13 @@
 
   (it "normalizes user trailing slashes in the configuration mappings"
     ;; User puts messy trailing slashes in the mapping list
-    (let ((eca-path-mappings '(("/Users/me/project/" . "/workspace/project/"))))
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/project/" . "/workspace/project/"))))
       (expect (eca--path-local-to-remote "/Users/me/project/src")
               :to-equal "/workspace/project/src"))))
 
 (describe "eca--path-local-to-remote nested"
   (it "handles nested local paths mapping to the same remote path"
-    (let ((eca-path-mappings '(("/Users/me/ws/nested" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/ws/nested" . "/workspace")
                                ("/Users/me/ws/nested/dev" . "/workspace"))))
       (expect (eca--path-local-to-remote "/Users/me/ws/nested/dev/project/file.el")
               :to-equal "/workspace/project/file.el")
@@ -114,14 +114,14 @@
 
 (describe "eca--path-remote-to-local nested"
   (it "handles nested local paths mapping to the same remote path"
-    (let ((eca-path-mappings '(("/Users/me/ws/nested" . "/workspace")
+    (let ((eca-local-to-remote-prefix-map '(("/Users/me/ws/nested" . "/workspace")
                                ("/Users/me/ws/nested/dev" . "/workspace"))))
       (expect (eca--path-remote-to-local "/workspace/project/file.el")
               :to-equal (expand-file-name "/Users/me/ws/nested/dev/project/file.el")))))
 
 (describe "eca--path-translation windows"
   (it "handles Windows paths correctly"
-    (let ((eca-path-mappings '(("C:/Users/me/ws/win-project" . "/workspace/win-project"))))
+    (let ((eca-local-to-remote-prefix-map '(("C:/Users/me/ws/win-project" . "/workspace/win-project"))))
       (expect (eca--path-local-to-remote "C:/Users/me/ws/win-project/src/main.rs")
               :to-equal "/workspace/win-project/src/main.rs")
       (expect (eca--path-remote-to-local "/workspace/win-project/src/main.rs")


### PR DESCRIPTION
eca previously sent host paths, breaking servers running in different environments (such as inside a docker container). This adds bidirectional mapping to rewrite host<->remote paths. 
