### PR TITLE
fix: keep ECA side windows dedicated

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -1989,17 +1989,17 @@ If `eca-chat-focus-on-open' is non-nil, the window is selected."
              (let* ((side eca-chat-window-side)
                     (slot 0)
                     (window-parameters '((no-delete-other-windows . t)))
-                    (display-buffer-alist
-                     `((,(regexp-quote (buffer-name buffer))
-                        (display-buffer-in-side-window)
-                        (side . ,side)
-                        (slot . ,slot)
-                        ,@(when (memq side '(left right))
-                            `((window-width . ,eca-chat-window-width)))
-                        ,@(when (memq side '(top bottom))
-                            `((window-height . ,eca-chat-window-height)))
-                        (window-parameters . ,window-parameters)))))
-               (display-buffer buffer))
+                    (display-action
+                     `((display-buffer-in-side-window)
+                       (side . ,side)
+                       (slot . ,slot)
+                       (dedicated . t)
+                       ,@(when (memq side '(left right))
+                           `((window-width . ,eca-chat-window-width)))
+                       ,@(when (memq side '(top bottom))
+                           `((window-height . ,eca-chat-window-height)))
+                       (window-parameters . ,window-parameters))))
+               (display-buffer buffer display-action))
            ;; Use regular buffer
            (display-buffer buffer))))
     ;; Select the window to give it focus if configured to do so

--- a/eca.el
+++ b/eca.el
@@ -472,13 +472,14 @@ When ARG is current prefix, ask for workspace roots to use."
         (widget-create (eca--tree-widget-open-all
                         (hierarchy-convert-to-tree-widget h label-fn)))
         (widget-setup))
-      (let* ((display-buffer-alist
-              `((,(regexp-quote (buffer-name b))
-                 (display-buffer-in-side-window)
-                 (side . bottom)
-                 (slot . 0)
-                 (window-parameters . ((no-delete-other-windows . t)))))))
-        (select-window (display-buffer b))))))
+      (select-window
+       (display-buffer
+        b
+        '((display-buffer-in-side-window)
+          (side . bottom)
+          (slot . 0)
+          (dedicated . t)
+          (window-parameters . ((no-delete-other-windows . t)))))))))
 
 ;;;###autoload
 (defun eca-open-global-config ()


### PR DESCRIPTION
Use explicit display-buffer actions instead of rebinding display-buffer-alist for chat and workspace windows.

The Emacs Lisp reference documents display-buffer-alist as a user option, so Lisp code should not override it for local buffer display rules.

Mark those side windows dedicated so commands like find-file, especially under persp-mode, do not replace the ECA side window.