### PR TITLE
fix(chat): switch chat tabs in place instead of new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bugfix: switching chat tabs via `tab-line-switch-to-next-tab`/`tab-line-switch-to-prev-tab` or clicking a tab now switches the chat in place instead of opening it in a new window.
 - Bugfix: trigger `@`/`#` chat completion even when a char like `(` immediately precedes it.
 - Bugfix: don't crash with `(wrong-type-argument stringp nil)` when `chat/askQuestion` sends options as plain strings or option objects without a `:label`. Options are normalized via `eca-chat--normalize-question-option` (string or plist) and the label always falls back to a non-nil string.
 - Bugfix: keep the `stop` button available while a question is pending. A pending question keeps the turn active server-side even when the chat reports idle, so the loading/stop transient segment and `eca-chat--stop-prompt` now treat a pending question like the loading state, and the transient area is refreshed when a question is shown/answered/cancelled.

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -2104,7 +2104,7 @@ If `eca-chat-focus-on-open' is non-nil, the window is selected."
                      `((display-buffer-in-side-window)
                        (side . ,side)
                        (slot . ,slot)
-                       (dedicated . t)
+                       (dedicated . side)
                        ,@(when (memq side '(left right))
                            `((window-width . ,eca-chat-window-width)))
                        ,@(when (memq side '(top bottom))


### PR DESCRIPTION
The chat side window was strongly dedicated (dedicated . t), so switch-to-buffer (used by tab-line tab switching and clicking a tab) refused to reuse it and popped the target chat into a new window. Weaken it to (dedicated . side), which keeps the persp-mode/find-file protection while allowing in-place buffer switching.