### PR TITLE
Fix tool and sub-agent state leaking between chats

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -3249,6 +3249,20 @@ CHILD, NAME, DOCSTRING and BODY are passed down."
   (setq-local eca-chat--history '())
   (setq-local eca-chat--history-index -1)
 
+  ;; Mutable defaults would otherwise be shared until locally assigned.
+  (setq-local eca-chat-expandable--id->ov
+              (make-hash-table :test 'equal))
+  (setq-local eca-chat--tool-call-prepare-counters
+              (make-hash-table :test 'equal))
+  (setq-local eca-chat--tool-call-prepare-content-cache
+              (make-hash-table :test 'equal))
+  (setq-local eca-chat--tool-call-elapsed-times
+              (make-hash-table :test 'equal))
+  (setq-local eca-chat--subagent-chat-id->tool-call-id
+              (make-hash-table :test 'equal))
+  (setq-local eca-chat--subagent-usage
+              (make-hash-table :test 'equal))
+
   ;; Show diff blocks in markdown-mode with colors.
   (setq-local markdown-fontify-code-blocks-natively t)
   ;; Enable gfm-view-mode-like rendering without read-only.

--- a/test/eca-chat-test.el
+++ b/test/eca-chat-test.el
@@ -1370,4 +1370,30 @@ does not treat the first line as metadata.  Returns FN's value."
               (delete-window win)))
           (kill-buffer buf))))))
 
+(describe "eca-chat subagent elapsed time"
+  (it "keeps elapsed tracking isolated when another chat finishes"
+    (spy-on 'eca-chat--force-tab-line-update)
+    (let ((session (make-eca--session))
+          chat-a chat-b)
+      (unwind-protect
+          (progn
+            (eca-chat-opened session '(:chatId "chat-A" :title "A"))
+            (eca-chat-opened session '(:chatId "chat-B" :title "B"))
+            (setq chat-a (eca-get (eca--session-chats session) "chat-A")
+                  chat-b (eca-get (eca--session-chats session) "chat-B"))
+            (with-current-buffer chat-a
+              (puthash "subagent-tool-call" (current-time)
+                       eca-chat--tool-call-elapsed-times))
+            (with-current-buffer chat-b
+              (eca-chat--tool-call-elapsed-stop-all))
+            (with-current-buffer chat-a
+              (expect (gethash "subagent-tool-call"
+                               eca-chat--tool-call-elapsed-times)
+                      :to-be-truthy)))
+        (dolist (buffer (list chat-a chat-b))
+          (when (buffer-live-p buffer)
+            (with-current-buffer buffer
+              (setq-local eca-chat--closed t))
+            (kill-buffer buffer)))))))
+
 ;;; eca-chat-test.el ends here


### PR DESCRIPTION
## What changed

Each chat now keeps its tool and sub-agent state separate.

Previously, several hash tables were marked as buffer-local but were initialized with shared mutable values. As a result, newly created chat buffers could still reference the same underlying state.

This affected:

- Tool-call timers
- Sub-agent routing
- Sub-agent usage information
- Tool preparation state
- Expandable tool content

## Why it only happened sometimes

The problem required a particular sequence of events:

1. Two or more chats had to be open at the same time.
2. One chat had to be running a tool or sub-agent.
3. Another chat then had to finish, stop, reset, or clear its tool state.

Normal updates usually affected unique tool-call IDs, so they did not obviously interfere with other chats. The problem became visible when a chat cleared an entire shared hash table, which also removed state belonging to other chats.

This made the behavior appear intermittent, but it depended on the timing and order of activity across multiple chats.

## Testing

Added a regression test that verifies finishing tool activity in one chat does not clear a sub-agent’s elapsed-time state in another chat.
