### PR TITLE
fix: add missing font-lock-face to mcps summary in header-line

### DIFF
--- a/eca-chat.el
+++ b/eca-chat.el
@@ -2392,6 +2392,7 @@ characters as part of the URL."
                          'pointer 'hand
                          'keymap mcp-keymap)
              (propertize (eca-chat--mcps-summary session)
+			 'font-lock-face 'eca-chat-option-value-face
                          'pointer 'hand
                          'keymap mcp-keymap)
              (propertize


### PR DESCRIPTION
 ## Summary
> - Fixed mcps summary text in chat header-line missing `font-lock-face` property
> - Added `'font-lock-face 'eca-chat-option-value-face` to the `propertize` call, matching the pattern used by model:, agent:, and variant: values
> - This ensures the mcps value text inherits the correct font and size styling
>
> Closes #287