### PR TITLE
Add Docker sandboxing example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,9 +387,12 @@ The same shape works for any wrapper. Replace the `jai` prefix and flags:
 <details>
 <summary><strong>Example: docker</strong></summary>
 
-Run ECA inside a Docker container that has the `eca` binary installed.
-This example injects API keys via environment variables and mounts the
-workspace root so file paths match the container layout.
+This example launches ECA in docker container. It uses
+`eca-local-to-remote-prefix-map` to translate paths between
+the host and container. Additionally, API keys are injected
+into the container. 
+
+> `my/eca-openrouter-key` is used instead of `${cmd:op ...}` because `${cmd:op ...}` would resolve inside the container, .
 
 ```elisp
 (defun my/eca-openrouter-key ()

--- a/README.md
+++ b/README.md
@@ -384,6 +384,70 @@ The same shape works for any wrapper. Replace the `jai` prefix and flags:
 
 </details>
 
+<details>
+<summary><strong>Example: docker</strong></summary>
+
+Run ECA inside a Docker container that has the `eca` binary installed.
+This example injects API keys via environment variables and mounts the
+workspace root so file paths match the container layout.
+
+```elisp
+(defun my/eca-openrouter-key ()
+  "Fetch the OpenRouter API key from 1Password."
+  (string-trim (shell-command-to-string
+                "op read op://Private/OpenRouter\\ API\\ Key/credential")))
+
+(defun my/eca-docker-wrapper (_command roots)
+  "Run ECA inside Docker, mounting the workspace root and injecting secrets."
+  (let* ((mount-src    (directory-file-name (expand-file-name (car roots))))
+         (project-name (file-name-nondirectory mount-src))
+         (mount-dest   (concat "/workspace/" project-name))
+         (or-key       (my/eca-openrouter-key)))
+
+    ;; Derive a path mapping so file URIs sent to the server match
+    ;; paths inside the container.
+    (unless (assoc mount-src eca-local-to-remote-prefix-map)
+      (push (cons mount-src mount-dest) eca-local-to-remote-prefix-map))
+    (setq eca-send-process-id nil)
+
+    (append (list "docker" "run" "--rm" "-i"
+                  "-v" (format "%s:%s" mount-src mount-dest)
+                  "-v" (format "%s:/root/.config/eca:ro"
+                               (expand-file-name "~/.config/eca"))
+                  "-e" (format "ECA_CONFIG={\"providers\":{\"openrouter\":{\"key\":\"%s\"}}}" or-key)
+                  "-w" mount-dest
+                  "eca-sandbox")
+            '("/root/.local/bin/eca" "server"))))
+
+(setq eca-process-wrapper-function #'my/eca-docker-wrapper)
+```
+
+Build the `eca-sandbox` image.  This Dockerfile downloads the pre-built
+`eca` binary from GitHub releases:
+
+```dockerfile
+FROM debian:stable-slim
+
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ~/.local/bin && \
+    if [ "$TARGETARCH" = "arm64" ]; then ARCH="aarch64"; else ARCH="amd64"; fi && \
+    curl -fsSL "https://github.com/editor-code-assistant/eca/releases/latest/download/eca-native-linux-${ARCH}.zip" -o eca.zip && \
+    unzip -q eca.zip -d ~/.local/bin && \
+    chmod +x ~/.local/bin/eca && \
+    rm eca.zip
+
+WORKDIR /workspace
+
+CMD ["bash"]
+```
+
+</details>
+
 ### Limitations
 
 - Sandbox tools that seal their directory whitelist at startup (jai,


### PR DESCRIPTION
### Known Issues

- After launching an agent in the sandbox, the `eca-prefix-map` is updated, however, it's never removed. Relaunching the agent outside the container will give the agent incorrect paths. The map must be cleared manually prior to launching outside the sandbox if desired.