### PR TITLE
Fix cancelled chat kill leaving the chat alive but orphaned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bugfix: quitting the delete-chat prompt (`C-g`) now really cancels the kill instead of leaving the chat alive but orphaned, without a window, tab or registry entry. Quitting it during `eca-chat-reset` leaves the session untouched as well, instead of adding a replacement chat next to the one that survived. The answered prompt no longer lingers in the echo area.
+
 ## 0.10.0
 
 - Bugfix: restore the status colors of the `mcps:` counts in the chat header-line, lost in #288 which overrode the per-status faces with `eca-chat-option-value-face`; that face is now merged with lower priority so both apply.

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -694,6 +694,12 @@ are not currently selected."
 ;; Internal
 
 (defvar-local eca-chat--closed nil)
+
+(defvar-local eca-chat--kill-delete-server-side nil
+  "Non-nil when the in-progress kill should also delete this chat.
+Set by `eca-chat--kill-buffer-query' and consumed by
+`eca-chat--delete-chat'.")
+
 (defvar-local eca-chat--history '())
 (defvar-local eca-chat--history-index -1)
 
@@ -940,26 +946,61 @@ sibling buffer switched to, or nil when SESSION has no other chat."
         (set-window-dedicated-p win dedicated)))
     other))
 
+(defun eca-chat--user-initiated-kill-p ()
+  "Return non-nil when the current command is closing this live chat.
+Only explicit kill commands and eca's own commands count, so that
+incidental `kill-buffer' calls from unrelated code do not tear the
+chat down.  Chats already marked `eca-chat--closed', and buffers
+without a chat id, are never considered."
+  (and (or (eq #'kill-current-buffer this-command)
+           (eq #'kill-buffer this-command)
+           (and (symbolp this-command)
+                (string-prefix-p "eca-" (symbol-name this-command))))
+       eca-chat--id
+       (not eca-chat--closed)))
+
+(defun eca-chat--kill-buffer-query ()
+  "Ask whether killing this chat should also delete it server-side.
+Returns nil to cancel the kill, leaving the chat untouched, so
+quitting with \\[keyboard-quit] is a no-op.  This belongs on
+`kill-buffer-query-functions' and not on `kill-buffer-hook', where
+the buffer is already doomed and only a signal could abort the
+kill, leaving the chat alive but orphaned."
+  (setq-local eca-chat--kill-delete-server-side nil)
+  (if (not (eca-chat--user-initiated-kill-p))
+      t
+    (unwind-protect
+        (condition-case nil
+            (progn
+              (when (yes-or-no-p
+                     "Delete chat from server side (otherwise it will just kill the buffer) ?")
+                (setq-local eca-chat--kill-delete-server-side t))
+              t)
+          (quit nil))
+      ;; The prompt is echoed back on both answer and quit, and nothing
+      ;; redisplays over it once the buffer is gone.
+      (message nil))))
+
 (defun eca-chat--delete-chat ()
   "Handle killing of the current chat buffer.
 Switches any window showing this chat to a sibling chat (so a
 dedicated chat window is not replaced by an unrelated buffer such
-as settings), drops the chat from the session registry, and, when
-confirmed, deletes it server-side."
-  (when (and (or (eq #'kill-current-buffer this-command)
-                 (eq #'kill-buffer this-command)
-                 (and (symbolp this-command)
-                      (string-prefix-p "eca-" (symbol-name this-command))))
-             eca-chat--id
-             (not eca-chat--closed))
+as settings), drops the chat from the session registry, and deletes
+it server-side when `eca-chat--kill-buffer-query' recorded that
+choice.
+
+Runs from `kill-buffer-hook', where the kill can no longer be
+aborted, so it must never prompt."
+  (when (eca-chat--user-initiated-kill-p)
     (let ((buffer (current-buffer))
-          (chat-id eca-chat--id))
+          (chat-id eca-chat--id)
+          (delete-server-side eca-chat--kill-delete-server-side))
       (when-let* ((session (ignore-errors (eca-session))))
         (eca-chat--switch-windows-to-sibling session buffer)
         (setf (eca--session-chats session)
               (eca-dissoc (eca--session-chats session) chat-id))
         (eca-chat--force-tab-line-update))
-      (when (yes-or-no-p "Delete chat from server side (otherwise it will just kill the buffer) ?")
+      (when delete-server-side
         (eca-api-request-sync (eca-session)
                               :method "chat/delete"
                               :params (list :chatId chat-id))))))
@@ -3419,6 +3460,7 @@ CHILD, NAME, DOCSTRING and BODY are passed down."
     (add-hook 'eldoc-documentation-functions #'eca-chat-eldoc-function nil t)
     (eldoc-mode 1)
 
+    (add-hook 'kill-buffer-query-functions #'eca-chat--kill-buffer-query nil t)
     (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t)
 
     ;; Paste image from clipboard support
@@ -5218,7 +5260,8 @@ Starting from the beginning of the buffer."
 (defun eca-chat-reset ()
   "Kill the current chat (asking whether to delete it server-side).
 Switch to the previous chat when the session has others, or start
-a fresh chat when this was the only one."
+a fresh chat when this was the only one.  Quitting the prompt
+cancels the reset, leaving the current chat as it was."
   (interactive)
   (let* ((session (eca-session))
          (buffer (eca-chat--get-last-buffer session)))
@@ -5226,9 +5269,10 @@ a fresh chat when this was the only one."
     (when (and (buffer-live-p buffer)
                (buffer-local-value 'eca-chat--id buffer))
       (let ((sibling (eca-chat--sibling-chat-buffer session buffer)))
-        (kill-buffer buffer)
-        (unless sibling
-          (eca-chat--new-chat session))))))
+        ;; nil when the user cancelled the kill: the chat is still there.
+        (when (kill-buffer buffer)
+          (unless sibling
+            (eca-chat--new-chat session)))))))
 
 ;;;###autoload
 (defun eca-chat-go-to-prev-user-message ()

--- a/test/eca-chat-kill-test.el
+++ b/test/eca-chat-kill-test.el
@@ -25,11 +25,36 @@ Returns the buffer.  Caller must kill it."
           (eca-assoc (eca--session-chats session) id buf))
     buf))
 
+(defun eca-kill-test--quit (&rest _)
+  "Signal `quit', simulating the user quitting the prompt.
+The real prompt may raise `minibuffer-quit' instead, which derives
+from `quit' and is handled by the same `condition-case'."
+  (signal 'quit nil))
+
+(defun eca-kill-test--install-kill-hooks (buffer)
+  "Install eca's kill query function and kill hook on BUFFER.
+Mirrors what `eca-chat-mode' registers, so tests exercise the real
+two-phase flow: confirmation in `kill-buffer-query-functions' and
+cleanup in `kill-buffer-hook'."
+  (with-current-buffer buffer
+    (add-hook 'kill-buffer-query-functions #'eca-chat--kill-buffer-query nil t)
+    (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t)))
+
 (defun eca-kill-test--kill-all (&rest buffers)
-  "Kill every live buffer in BUFFERS, ignoring the eca kill hook."
-  (let ((kill-buffer-hook nil))
-    (dolist (buf buffers)
-      (when (buffer-live-p buf) (kill-buffer buf)))))
+  "Kill every live buffer in BUFFERS, ignoring the eca kill hooks.
+The hooks are removed buffer-locally rather than let-bound: binding
+`kill-buffer-hook' / `kill-buffer-query-functions' only shadows
+their global value and would still run buffer-local entries, which
+here would call the real `yes-or-no-p' and block the test run."
+  (dolist (buf buffers)
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (remove-hook 'kill-buffer-query-functions
+                     #'eca-chat--kill-buffer-query t)
+        (remove-hook 'kill-buffer-hook #'eca-chat--delete-chat t))
+      (let ((kill-buffer-hook nil)
+            (kill-buffer-query-functions nil))
+        (kill-buffer buf)))))
 
 ;; ---------------------------------------------------------------------------
 ;; eca-chat--sibling-chat-buffer
@@ -144,8 +169,7 @@ Returns the buffer.  Caller must kill it."
           (progn
             (setq a (eca-kill-test--make-chat session "A")
                   b (eca-kill-test--make-chat session "B"))
-            (with-current-buffer b
-              (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t))
+            (eca-kill-test--install-kill-hooks b)
             (set-window-buffer (selected-window) b)
             (let ((this-command #'kill-buffer))
               (kill-buffer b))
@@ -162,12 +186,129 @@ Returns the buffer.  Caller must kill it."
           (progn
             (setq a (eca-kill-test--make-chat session "A"))
             (with-current-buffer a
-              (setq-local eca-chat--closed t)
-              (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t))
+              (setq-local eca-chat--closed t))
+            (eca-kill-test--install-kill-hooks a)
             (let ((this-command #'kill-buffer))
               (kill-buffer a))
             (expect 'yes-or-no-p :not :to-have-been-called))
-        (eca-kill-test--kill-all a)))))
+        (eca-kill-test--kill-all a))))
+
+  (it "deletes the chat server side when the prompt is answered yes"
+    (let ((session (make-eca--session)) a b)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'yes-or-no-p :and-return-value t)
+      (spy-on 'eca-api-request-sync)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A")
+                  b (eca-kill-test--make-chat session "B"))
+            (eca-kill-test--install-kill-hooks b)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            (expect (buffer-live-p b) :to-be nil)
+            (expect 'eca-api-request-sync :to-have-been-called))
+        (eca-kill-test--kill-all a b))))
+
+  (it "only kills the buffer when the prompt is answered no"
+    (let ((session (make-eca--session)) a b)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'yes-or-no-p :and-return-value nil)
+      (spy-on 'eca-api-request-sync)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A")
+                  b (eca-kill-test--make-chat session "B"))
+            (eca-kill-test--install-kill-hooks b)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            (expect (buffer-live-p b) :to-be nil)
+            (expect 'eca-api-request-sync :not :to-have-been-called))
+        (eca-kill-test--kill-all a b))))
+
+  (it "clears the echo area so the answered prompt does not linger"
+    ;; `yes-or-no-p' echoes the prompt back together with the answer,
+    ;; and once the chat buffer is gone nothing redisplays over it, so
+    ;; the stale prompt stayed on screen after a plain buffer kill.
+    (let ((session (make-eca--session)) a b)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'yes-or-no-p :and-return-value nil)
+      (spy-on 'eca-api-request-sync)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (spy-on 'message)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A")
+                  b (eca-kill-test--make-chat session "B"))
+            (eca-kill-test--install-kill-hooks b)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            (expect 'message :to-have-been-called-with nil))
+        (eca-kill-test--kill-all a b)))))
+
+;; ---------------------------------------------------------------------------
+;; Cancelling the kill by quitting the prompt
+;; ---------------------------------------------------------------------------
+
+(describe "cancelling a chat kill by quitting the prompt"
+
+  ;; The confirmation used to run from `kill-buffer-hook', after the
+  ;; window had already been switched away and the chat dropped from the
+  ;; registry.  Quitting then left the buffer alive but orphaned, which
+  ;; looked exactly like a successful kill.  Quitting must now be a
+  ;; complete no-op.
+
+  (it "keeps the buffer alive, registered and displayed"
+    (let ((session (make-eca--session)) a b)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'yes-or-no-p :and-call-fake #'eca-kill-test--quit)
+      (spy-on 'eca-api-request-sync)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (spy-on 'message)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A")
+                  b (eca-kill-test--make-chat session "B"))
+            (eca-kill-test--install-kill-hooks b)
+            (set-window-buffer (selected-window) b)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            ;; Nothing at all happened, and the echo area was cleaned up.
+            (expect (buffer-live-p b) :to-be t)
+            (expect 'message :to-have-been-called-with nil)
+            (expect (eca-get (eca--session-chats session) "B") :to-be b)
+            (expect (window-buffer (selected-window)) :to-be b)
+            (expect 'eca-api-request-sync :not :to-have-been-called)
+            (expect 'eca-chat--force-tab-line-update :not :to-have-been-called))
+        (eca-kill-test--kill-all a b))))
+
+  (it "leaves the chat killable again afterwards"
+    (let ((session (make-eca--session)) a b)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'eca-api-request-sync)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A")
+                  b (eca-kill-test--make-chat session "B"))
+            (eca-kill-test--install-kill-hooks b)
+            (set-window-buffer (selected-window) b)
+            ;; First attempt: cancelled.
+            (spy-on 'yes-or-no-p :and-call-fake #'eca-kill-test--quit)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            (expect (buffer-live-p b) :to-be t)
+            ;; Second attempt: confirmed, and the stale "delete server
+            ;; side" answer from the cancelled attempt is not reused.
+            (spy-on 'yes-or-no-p :and-return-value nil)
+            (let ((this-command #'kill-buffer))
+              (kill-buffer b))
+            (expect (buffer-live-p b) :to-be nil)
+            (expect (eca-get (eca--session-chats session) "B") :to-be nil)
+            (expect (window-buffer (selected-window)) :to-be a)
+            (expect 'eca-api-request-sync :not :to-have-been-called))
+        (eca-kill-test--kill-all a b)))))
 
 ;; ---------------------------------------------------------------------------
 ;; eca-chat-deleted (server-side deletion notification)
@@ -205,8 +346,7 @@ Returns the buffer.  Caller must kill it."
           (progn
             (setq a (eca-kill-test--make-chat session "A")
                   b (eca-kill-test--make-chat session "B"))
-            (with-current-buffer b
-              (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t))
+            (eca-kill-test--install-kill-hooks b)
             (setf (eca--session-last-chat-buffer session) b)
             (set-window-buffer (selected-window) b)
             (let ((this-command #'eca-chat-reset))
@@ -226,13 +366,35 @@ Returns the buffer.  Caller must kill it."
       (unwind-protect
           (progn
             (setq a (eca-kill-test--make-chat session "A"))
-            (with-current-buffer a
-              (add-hook 'kill-buffer-hook #'eca-chat--delete-chat nil t))
+            (eca-kill-test--install-kill-hooks a)
             (setf (eca--session-last-chat-buffer session) a)
             (let ((this-command #'eca-chat-reset))
               (eca-chat-reset))
             (expect (buffer-live-p a) :to-be nil)
             (expect 'eca-chat--new-chat :to-have-been-called-with session))
+        (eca-kill-test--kill-all a))))
+
+  (it "does not start a new chat when the kill is cancelled"
+    ;; Cancelling used to abort `eca-chat-reset' by signalling out of
+    ;; `kill-buffer-hook'.  Now the kill is declined normally, so the
+    ;; command keeps running and must not replace a chat that is still
+    ;; alive.
+    (let ((session (make-eca--session)) a)
+      (spy-on 'eca-session :and-return-value session)
+      (spy-on 'eca-assert-session-running)
+      (spy-on 'eca-chat--new-chat)
+      (spy-on 'yes-or-no-p :and-call-fake #'eca-kill-test--quit)
+      (spy-on 'eca-chat--force-tab-line-update)
+      (unwind-protect
+          (progn
+            (setq a (eca-kill-test--make-chat session "A"))
+            (eca-kill-test--install-kill-hooks a)
+            (setf (eca--session-last-chat-buffer session) a)
+            (let ((this-command #'eca-chat-reset))
+              (eca-chat-reset))
+            (expect (buffer-live-p a) :to-be t)
+            (expect (eca-get (eca--session-chats session) "A") :to-be a)
+            (expect 'eca-chat--new-chat :not :to-have-been-called))
         (eca-kill-test--kill-all a)))))
 
 (provide 'eca-chat-kill-test)


### PR DESCRIPTION
## Changes

- Move the delete-chat confirmation to `kill-buffer-query-functions`, so quitting it cancels the kill instead of leaving the chat orphaned.
- Keep `eca-chat-reset` from starting a replacement chat when the kill was cancelled.
- Clear the prompt echoed back to the echo area after answering.
- Add specs for the answer, cancel and echo paths.