### PR TITLE
Normalize workspace dirs so they can be removed again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bugfix: `eca-chat-remove-workspace-root` failed with `Workspace folder not found` for a dir shown in the mode-line. Workspace dirs are matched with `string=`, but `C-u M-x eca` stored them as `read-directory-name` returned them (`~/proj/`) while add and remove expanded their argument, and `expand-file-name` keeps trailing slashes so `/x` and `/x/` never matched either. Dirs are now expanded and stripped of the trailing slash wherever they are stored or compared, which also stops `M-x eca` opening a second session for a root already held under a different spelling.
+
 - Bugfix: shell command breakdown no longer stays yellow when the tool call was auto-approved (e.g. trust mode) or already ran; commands now show green once approved, keeping yellow only while approval is pending.
 
 - Turn `eca-workspaces` into a live dashboard: rows refresh automatically as chats change state, each chat showing status (⏳ running, 🚧 pending approval, ❓ waiting answer), elapsed time, cost and model, with workspaces sorted alphabetically. Actions on the entry at point, all listed in a transient menu (`?`): new chat with optional initial prompt (`+`), delete chat or stop workspace with confirmation (`d`/`DEL`), rename (`r`), fork (`f`), compact (`C`), select model/variant (`m`/`v`), accept/reject pending tool calls (`a`/`A`/`x`), stop prompt (`s`) and resume a closed chat (`R`).

--- a/eca-util.el
+++ b/eca-util.el
@@ -243,7 +243,7 @@ nil otherwise."
 
 (defun eca--session-add-workspace-folder (session folder)
   "Add FOLDER to SESSION's workspace-folders and notify the server."
-  (let ((folder (expand-file-name folder)))
+  (let ((folder (directory-file-name (expand-file-name folder))))
     (unless (--first (string= it folder)
                      (eca--session-workspace-folders session))
       (setf (eca--session-workspace-folders session)
@@ -266,7 +266,7 @@ an empty list would make the session unreachable.  In `merged' worktree
 mode, a removed folder whose git-common-dir still matches another
 folder in the session can be auto-re-added by `eca-session' the next
 time a buffer under it is visited."
-  (let* ((folder (expand-file-name folder))
+  (let* ((folder (directory-file-name (expand-file-name folder)))
          (folders (eca--session-workspace-folders session)))
     (cond
      ((not (--first (string= it folder) folders))
@@ -289,7 +289,8 @@ time a buffer under it is visited."
 (defun eca-session ()
   "Return the session related to root of current buffer otherwise nil."
   (or (eca-get eca--sessions eca--session-id-cache)
-      (let* ((root (funcall eca-find-root-for-buffer-function))
+      (let* ((root (directory-file-name
+                    (expand-file-name (funcall eca-find-root-for-buffer-function))))
              (session (or (-first (lambda (session)
                                     (--first (string= it root)
                                              (eca--session-workspace-folders session)))
@@ -311,7 +312,8 @@ time a buffer under it is visited."
   (let ((session (make-eca--session))
         (id (cl-incf eca--session-ids)))
     (setf (eca--session-id session) id)
-    (setf (eca--session-workspace-folders session) workspace-roots)
+    (setf (eca--session-workspace-folders session)
+          (-distinct (--map (directory-file-name (expand-file-name it)) workspace-roots)))
     (setf (eca--session-chat-default-trust session)
           (and (boundp 'eca-chat-trust-enable)
                (symbol-value 'eca-chat-trust-enable)))

--- a/test/eca-chat-test.el
+++ b/test/eca-chat-test.el
@@ -1705,4 +1705,87 @@ does not treat the first line as metadata.  Returns FN's value."
       (expect (get-text-property 2 'font-lock-face line)
               :to-be 'eca-chat-shell-command-remembered-face))))
 
+(defvar eca-chat-test--ws-session nil
+  "Session the workspace-root command specs operate on.")
+
+(defun eca-chat-test--add-root (picked)
+  "Run `eca-chat-add-workspace-root' as if the user picked PICKED."
+  (cl-letf (((symbol-function 'read-directory-name) (lambda (&rest _) picked)))
+    (call-interactively #'eca-chat-add-workspace-root)))
+
+(defun eca-chat-test--remove-root (choose)
+  "Run `eca-chat-remove-workspace-root' picking via CHOOSE.
+CHOOSE receives the candidate list the command offers."
+  (cl-letf (((symbol-function 'completing-read)
+             (lambda (_prompt collection &rest _) (funcall choose collection))))
+    (call-interactively #'eca-chat-remove-workspace-root)))
+
+(describe "workspace root commands end to end"
+  (before-each
+    (spy-on 'eca-api-notify)
+    (spy-on 'eca-info)
+    (spy-on 'eca-warn)
+    (spy-on 'force-mode-line-update)
+    (setq eca-chat-test--ws-session (make-eca--session))
+    ;; Read the variable at call time: specs that rebuild it via
+    ;; `eca-create-session' must be seen by the commands under test.
+    (spy-on 'eca-session :and-call-fake (lambda () eca-chat-test--ws-session)))
+
+  (after-each
+    (setq eca-chat-test--ws-session nil))
+
+  ;; The bug: the dir was added and shown in the mode line, but removing
+  ;; it reported "Workspace folder not found".
+  (it "removes a dir the user just added"
+    (setf (eca--session-workspace-folders eca-chat-test--ws-session)
+          (list (expand-file-name "/tmp/root")))
+    (eca-chat-test--add-root "/tmp/added/")
+    (expect (eca--session-workspace-folders eca-chat-test--ws-session)
+            :to-equal (list (expand-file-name "/tmp/root")
+                            (expand-file-name "/tmp/added")))
+    (eca-chat-test--remove-root #'cadr)
+    (expect (eca--session-workspace-folders eca-chat-test--ws-session)
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "removes a dir added in ~ form"
+    (setf (eca--session-workspace-folders eca-chat-test--ws-session)
+          (list (expand-file-name "/tmp/root")))
+    (eca-chat-test--add-root "~/added/")
+    (eca-chat-test--remove-root #'cadr)
+    (expect (eca--session-workspace-folders eca-chat-test--ws-session)
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "removes an original session root stored in ~ form"
+    (let ((eca--sessions '()))
+      (setq eca-chat-test--ws-session (eca-create-session (list "~/root/" "/tmp/other/")))
+      (eca-chat-test--add-root "/tmp/added")
+      (eca-chat-test--remove-root #'car)
+      (expect (eca--session-workspace-folders eca-chat-test--ws-session)
+              :to-equal (list (expand-file-name "/tmp/other")
+                              (expand-file-name "/tmp/added")))))
+
+  (it "offers no candidate that cannot be removed"
+    (dolist (dir '("~/root" "/tmp/other" "/tmp/added"))
+      (let ((eca--sessions '()))
+        (setq eca-chat-test--ws-session (eca-create-session (list "~/root/" "/tmp/other/")))
+        (eca-chat-test--add-root "/tmp/added/")
+        (let ((stored (directory-file-name (expand-file-name dir)))
+              (before (eca--session-workspace-folders eca-chat-test--ws-session)))
+          (eca-chat-test--remove-root
+           (lambda (candidates) (--first (string= it stored) candidates)))
+          (expect (eca--session-workspace-folders eca-chat-test--ws-session)
+                  :to-equal (remove stored before))))))
+
+  (it "keeps the mode line in sync with what can be removed"
+    (setf (eca--session-workspace-folders eca-chat-test--ws-session)
+          (list (expand-file-name "/tmp/root")))
+    (expect (eca-chat--mode-line-module eca-chat-test--ws-session :remove-workspace-button)
+            :to-be nil)
+    (eca-chat-test--add-root "/tmp/added/")
+    (expect (eca-chat--mode-line-module eca-chat-test--ws-session :remove-workspace-button)
+            :not :to-be nil)
+    (eca-chat-test--remove-root #'cadr)
+    (expect (eca-chat--mode-line-module eca-chat-test--ws-session :remove-workspace-button)
+            :to-be nil)))
+
 ;;; eca-chat-test.el ends here

--- a/test/eca-util-test.el
+++ b/test/eca-util-test.el
@@ -4,6 +4,7 @@
 
 (require 'buttercup)
 (require 'eca-util)
+(require 'eca-api)
 
 (defvar eca-local-to-remote-prefix-map)
 
@@ -264,6 +265,112 @@
         (eca--git-common-dir "/tmp/eca-repo")
         (eca-delete-session session)
         (expect (hash-table-count eca--git-common-dir-cache) :to-equal 0)))))
+
+(defun eca-util-test--add-then-remove (initial added removed)
+  "Add ADDED to a session holding INITIAL, remove REMOVED, return its dirs."
+  (let ((session (make-eca--session)))
+    (setf (eca--session-workspace-folders session) initial)
+    (eca--session-add-workspace-folder session added)
+    (eca--session-remove-workspace-folder session removed)
+    (eca--session-workspace-folders session)))
+
+(describe "workspace dir add/remove round-trip"
+  (before-each
+    (spy-on 'eca-api-notify)
+    (spy-on 'eca-info)
+    (spy-on 'eca-warn))
+
+  (it "removes a dir added with a trailing slash"
+    (expect (eca-util-test--add-then-remove
+             (list (expand-file-name "/tmp/root")) "/tmp/added/" "/tmp/added")
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "removes a dir offered back with a trailing slash"
+    (expect (eca-util-test--add-then-remove
+             (list (expand-file-name "/tmp/root")) "/tmp/added" "/tmp/added/")
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "removes a dir added in ~ form"
+    (expect (eca-util-test--add-then-remove
+             (list (expand-file-name "/tmp/root")) "~/added/"
+             (expand-file-name "~/added"))
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "removes a ~ form dir picked from the UI verbatim"
+    (expect (eca-util-test--add-then-remove
+             (list (expand-file-name "/tmp/root")) "~/added" "~/added")
+            :to-equal (list (expand-file-name "/tmp/root"))))
+
+  (it "does not add the same dir twice in different shapes"
+    (let ((session (make-eca--session)))
+      (setf (eca--session-workspace-folders session)
+            (list (expand-file-name "/tmp/root")))
+      (eca--session-add-workspace-folder session "/tmp/added")
+      (eca--session-add-workspace-folder session "/tmp/added/")
+      (expect (eca--session-workspace-folders session)
+              :to-equal (list (expand-file-name "/tmp/root")
+                              (expand-file-name "/tmp/added")))))
+
+  (it "still warns when the dir really is absent"
+    (let ((session (make-eca--session))
+          (dirs (list (expand-file-name "/tmp/root")
+                      (expand-file-name "/tmp/other"))))
+      (setf (eca--session-workspace-folders session) dirs)
+      (eca--session-remove-workspace-folder session "/tmp/nope")
+      (expect 'eca-warn :to-have-been-called)
+      (expect (eca--session-workspace-folders session) :to-equal dirs)))
+
+  (it "still refuses to remove the last dir"
+    (let ((session (make-eca--session)))
+      (setf (eca--session-workspace-folders session)
+            (list (expand-file-name "/tmp/root")))
+      (expect (eca--session-remove-workspace-folder session "/tmp/root/")
+              :to-throw 'user-error))))
+
+(describe "eca-create-session"
+  (before-each
+    (spy-on 'eca-api-notify))
+
+  (it "normalizes roots so they can be removed later"
+    (let* ((eca--sessions '())
+           (session (eca-create-session (list "~/proj/" "/tmp/other/"))))
+      (expect (eca--session-workspace-folders session)
+              :to-equal (list (expand-file-name "~/proj")
+                              (expand-file-name "/tmp/other")))))
+
+  (it "collapses roots that only differ in shape"
+    (let* ((eca--sessions '())
+           (session (eca-create-session (list "/tmp/proj" "/tmp/proj/"))))
+      (expect (eca--session-workspace-folders session)
+              :to-equal (list (expand-file-name "/tmp/proj")))))
+
+  (it "keeps the filesystem root usable"
+    ;; Stripping the trailing slash must not eat the root itself.
+    (let* ((eca--sessions '())
+           (session (eca-create-session '("/"))))
+      (expect (eca--session-workspace-folders session)
+              :to-equal (list (expand-file-name "/"))))))
+
+(describe "eca-session workspace resolution"
+  (before-each
+    (spy-on 'eca-api-notify))
+
+  (it "resolves a root reported with a trailing slash"
+    ;; `project-root' and `default-directory' both end in a slash, while
+    ;; stored dirs do not; the lookup must still match.
+    (let* ((eca--sessions '())
+           (session (eca-create-session (list (expand-file-name "/tmp/proj"))))
+           (eca-find-root-for-buffer-function
+            (lambda () (file-name-as-directory (expand-file-name "/tmp/proj")))))
+      (with-temp-buffer
+        (expect (eca-session) :to-be session))))
+
+  (it "resolves a root reported in ~ form"
+    (let* ((eca--sessions '())
+           (session (eca-create-session (list (expand-file-name "~/proj"))))
+           (eca-find-root-for-buffer-function (lambda () "~/proj/")))
+      (with-temp-buffer
+        (expect (eca-session) :to-be session)))))
 
 (provide 'eca-util-test)
 ;;; eca-util-test.el ends here


### PR DESCRIPTION
## Summary

- `eca-chat-remove-workspace-root` reported `Workspace folder not found` for a dir the mode line was showing and the prompt had just offered. Workspace dirs are matched with `string=`, but each entry point normalized differently: `eca--discover-workspaces` (`C-u M-x eca`) hands `read-directory-name` values straight to `eca-create-session`, which stored them verbatim, so a dir picked as `~/proj/` stayed unexpanded while add/remove expanded their argument.
- `expand-file-name` preserves trailing slashes, so `/x` vs `/x/` was a second, independent source of mismatches: `project-root` and `default-directory` always end in a slash, `read-directory-name` may not.
- Expand and drop the trailing slash at all four places a workspace dir is stored or compared, and dedupe in `eca-create-session` since normalizing can collapse entries that used to be distinct strings. As a side effect `M-x eca` no longer opens a second session for a root an existing session already holds under a different spelling.

## Notes

Normalizing the root in `eca-session` is required rather than incidental: stored dirs no longer carry a trailing slash while buffer roots do, so the lookup would otherwise stop matching.

Symlinks are deliberately not resolved (no `file-truename`), so `/tmp` and `/private/tmp` remain distinct and the path reported to the server stays the one the user picked.

## Testing

17 specs added, 445 total passing. Reverting only `eca-util.el` while keeping the new specs fails 12 of them and nothing else, so they are genuine regression guards rather than tests written around the implementation.

Also exercised end to end in a live Emacs against the real commands, driving `eca-chat-add-workspace-root` / `eca-chat-remove-workspace-root` with six input shapes (trailing slash, none, `~` with and without slash, `..` segments, symlink target): before the fix the `~` case failed exactly as reported, after it all six add and remove cleanly.
