### PR TITLE
bind TAB instead of raw <tab> on expandable labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bugfix: TAB on an expandable block label no longer blocks the `<tab>` -> `TAB` key translation, extending the fix in #281 to the label's `keymap` text property, which outranks the mode map. It bound the raw `<tab>` event and shadowed layered keymaps binding only `TAB`; it now binds `TAB`, which also makes the label's own binding reachable in terminal frames, where `<tab>` is never sent.
 - Show the summaries of tool calls pending approval in the inline prompt overlay status instead of the generic "Waiting for tool call approval" progress text (which overwrote the approval status), so it's clear what is about to run. With multiple pending tools, resolving one now keeps showing the remaining summaries, and approving from another client clears the stale approve/reject hints.
 - Bugfix: a region ending at the beginning of a line (whole-lines selection) no longer includes that extra line in the lines range sent by the `eca-chat-add-context-*` commands, and ranges/cursor positions computed in narrowed buffers now use absolute file line numbers.
 

--- a/eca-chat-expandable.el
+++ b/eca-chat-expandable.el
@@ -289,7 +289,7 @@ NESTED-PROPS is a plist with :parent-id and :label-indent for nested blocks."
                                                                                                             (make-string (length eca-chat-expandable-block-open-symbol) ?\s)))))
                                   'keymap (let ((km (make-sparse-keymap)))
                                             (define-key km (kbd "<mouse-1>") (lambda () (interactive) (eca-chat--expandable-content-toggle id)))
-                                            (define-key km (kbd "<tab>") (lambda () (interactive) (eca-chat--expandable-content-toggle id)))
+                                            (define-key km (kbd "TAB") (lambda () (interactive) (eca-chat--expandable-content-toggle id)))
                                             (define-key km (kbd "RET") (lambda () (interactive) (eca-chat--expandable-content-toggle id)))
                                             km)
                                   'help-echo "mouse-1 / tab / RET: expand/collapse"))

--- a/test/eca-chat-test.el
+++ b/test/eca-chat-test.el
@@ -1699,6 +1699,33 @@ does not treat the first line as metadata.  Returns FN's value."
             :to-be #'eca-chat--key-pressed-queue)))
 
 ;; ---------------------------------------------------------------------------
+;; Expandable block label keymap
+;; ---------------------------------------------------------------------------
+
+(defun eca-chat-test--expandable-label-keymap ()
+  "Render an expandable block and return the label's `keymap' property."
+  (with-temp-buffer
+    (let ((eca-chat-expandable--id->ov (make-hash-table :test 'equal)))
+      (eca-chat--insert-expandable-block "test-id" "Label" "content" "" "" ""))
+    (get-text-property (point-min) 'keymap)))
+
+(describe "expandable block label keymap"
+
+  (it "binds TAB and RET to the toggle"
+    (let ((km (eca-chat-test--expandable-label-keymap)))
+      (expect (functionp (lookup-key km (kbd "TAB"))) :to-be t)
+      (expect (functionp (lookup-key km (kbd "RET"))) :to-be t)))
+
+  ;; The label keymap comes from a `keymap' text property, which outranks
+  ;; the mode map, so binding the raw events here would block the
+  ;; <tab> -> TAB and <return> -> RET translations while point is on a
+  ;; label and shadow any layered keymap binding only TAB/RET.
+  (it "does not bind the raw <tab> or <return> events"
+    (let ((km (eca-chat-test--expandable-label-keymap)))
+      (expect (lookup-key km (kbd "<tab>")) :to-be nil)
+      (expect (lookup-key km (kbd "<return>")) :to-be nil))))
+
+;; ---------------------------------------------------------------------------
 ;; eca-chat--shell-command-state-face
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Changes

- Bind `TAB` instead of the raw `<tab>` event on expandable block labels, so their `keymap` text property no longer blocks `<tab>` → `TAB` translation or shadows layered keymaps (same class as #281).
- Also makes the label binding work in terminal frames, which never send `<tab>`.