### PR TITLE
Add option to hide chat tab close buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Chat
 - `eca-chat-expand-pending-approval-tools`: Whether to auto-expand tool calls that are pending approval.
 - `eca-chat-shrink-called-tools`: Whether to auto-shrink tool calls after they have been executed.
 - `eca-chat-tab-line`: Whether to show a tab line with chat tabs at the top of each chat window (default `t`). Each tab shows the chat status (pending approval, loading) and title.
+- `eca-chat-tab-line-close-button-show`: Whether to show close buttons on ECA chat tab-line tabs (default `t`).
 - `eca-chat-custom-model`: Override the model used for chat (nil = server default).
 - `eca-chat-custom-agent`: Override the chat agent (nil = server default).
 - `eca-chat-usage-string-format`: Controls what usage information (tokens/costs/limits) is shown in the mode-line.

--- a/eca-chat.el
+++ b/eca-chat.el
@@ -183,6 +183,12 @@ for every open chat in the session.  Each tab shows the chat status
   :type 'boolean
   :group 'eca)
 
+(defcustom eca-chat-tab-line-close-button-show t
+  "Whether to show close buttons on ECA chat tab-line tabs.
+When nil, chat tabs are still shown but the close button is hidden."
+  :type 'boolean
+  :group 'eca)
+
 (defcustom eca-chat-custom-model nil
   "Which model to use during chat, nil means use server's default.
 Must be a valid model supported by server, check `eca-chat-select-model`."
@@ -3526,7 +3532,7 @@ CHILD, NAME, DOCSTRING and BODY are passed down."
              (require 'tab-line)
              (setq-local tab-line-tabs-function #'eca-chat--tab-line-tabs)
              (setq-local tab-line-new-button-show t)
-             (setq-local tab-line-close-button-show t)
+             (setq-local tab-line-close-button-show eca-chat-tab-line-close-button-show)
              (setq-local tab-line-new-tab-function #'eca-chat-new)
              (setq-local tab-line-separator "")
              (setq-local tab-line-tab-face-functions '(eca-chat--tab-line-face))


### PR DESCRIPTION
## Description

The chat tab line currently always enables close buttons when chat tabs are shown. Users who prefer managing chat buffers through commands or custom tab-line UI cannot keep chat tabs visible while hiding those buttons.

## Changes

- Add `eca-chat-tab-line-close-button-show` to control whether chat tabs render close buttons.
- Use the new option when enabling chat tab-line buffers, preserving the existing default behavior.
- Document the option in the README.
